### PR TITLE
ci: adapt prebuilt workflow for zoompilot fork

### DIFF
--- a/.github/workflows/sunnypilot-build-prebuilt.yaml
+++ b/.github/workflows/sunnypilot-build-prebuilt.yaml
@@ -5,7 +5,7 @@ env:
   OUTPUT_DIR: ${{ github.workspace }}/output
   CI_DIR: ${{ github.workspace }}/release/ci
   SCONS_CACHE_DIR: ${{ github.workspace }}/release/ci/scons_cache
-  PUBLIC_REPO_URL: "https://github.com/sunnypilot/sunnypilot"
+  PUBLIC_REPO_URL: "https://github.com/zoompilot/zoompilot"
 
   # Branch configurations
   STAGING_SOURCE_BRANCH: 'master'
@@ -14,18 +14,7 @@ env:
   SOURCE_BRANCH: "${{ github.head_ref || github.ref_name }}"
 
 on:
-  push:
-    branches: [ master, master-dev ]
-    tags: [ 'release/*' ]
-  pull_request_target:
-    types: [ labeled ]
   workflow_dispatch:
-    inputs:
-      wait_for_tests:
-        description: 'Wait for tests to finish'
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   prepare_strategy:
@@ -86,25 +75,8 @@ jobs:
           echo "build=$BUILD" >> $GITHUB_OUTPUT
           cat $GITHUB_OUTPUT
 
-  validate_tests:
-    runs-on: ubuntu-24.04
-    needs: [ prepare_strategy ]
-    if: ${{
-      ((github.event_name == 'workflow_dispatch' && inputs.wait_for_tests) ||
-      (github.event_name == 'push' && needs.prepare_strategy.outputs.is_stable_branch == 'true') ||
-      contains(github.event_name, 'pull_request') && (github.event.action == 'labeled' && github.event.label.name == 'prebuilt'))
-      }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Wait for Tests
-        uses: ./.github/workflows/wait-for-action # Path to where you place the action
-        with:
-          workflow: tests.yaml # The workflow file to monitor
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          should-wait-for-start: ${{ github.event_name == 'push' && 'true' || 'false' }}
-
   build:
-    needs: [ validate_tests, prepare_strategy ]
+    needs: [ prepare_strategy ]
     concurrency:
       group: build-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: false
@@ -114,13 +86,7 @@ jobs:
       version: ${{ needs.prepare_strategy.outputs.version }}
       extra_version_identifier: ${{ needs.prepare_strategy.outputs.extra_version_identifier }}
       commit_sha: ${{ github.sha }}
-    if: ${{
-      (always() && !cancelled() && !failure()) &&
-      needs.prepare_strategy.result == 'success' &&
-      (needs.validate_tests.result == 'success' || needs.validate_tests.result == 'skipped') &&
-      (!contains(github.event_name, 'pull_request') ||
-      (github.event.action == 'labeled' && github.event.label.name == 'prebuilt'))
-      }}
+    if: ${{ (always() && !cancelled() && !failure()) && needs.prepare_strategy.result == 'success' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -257,7 +223,7 @@ jobs:
       # Otherwise, if a job is waiting to be published due to environment wait time, it would be canceled by a new commit and restart the wait time.
       group: ${{ needs.prepare_strategy.outputs.publish_concurrency_group }}
       cancel-in-progress: ${{ needs.prepare_strategy.outputs.cancel_publish_in_progress == 'true' }}
-    if: ${{ (always() && !cancelled() && !failure()) && needs.build.result == 'success' && needs.prepare_strategy.result == 'success' && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt')) }}
+    if: ${{ (always() && !cancelled() && !failure()) && needs.build.result == 'success' && needs.prepare_strategy.result == 'success' }}
     needs: [ build, prepare_strategy ]
     runs-on: ubuntu-24.04
     environment: ${{ needs.prepare_strategy.outputs.environment }}
@@ -291,7 +257,7 @@ jobs:
             "${{ env.OUTPUT_DIR }}" \
             "${{ needs.build.outputs.new_branch }}" \
             "${{ needs.build.outputs.version }}" \
-            "https://x-access-token:${{github.token}}@github.com/sunnypilot/sunnypilot.git" \
+            "https://x-access-token:${{github.token}}@github.com/zoompilot/zoompilot.git" \
             "${{ needs.build.outputs.extra_version_identifier }}"
 
           echo ""
@@ -307,73 +273,3 @@ jobs:
             TAG="${{ needs.prepare_strategy.outputs.environment }}/${{ needs.prepare_strategy.outputs.version }}/${{ needs.prepare_strategy.outputs.build }}"
             git tag -f -a ${TAG} -m "${{ needs.prepare_strategy.outputs.environment }} @ ${{ needs.prepare_strategy.outputs.version }} of build ${{ needs.build.outputs.build }}."
             git push -f origin ${TAG}
-
-  notify:
-    needs:
-    - prepare_strategy
-    - build
-    - publish
-    runs-on: ubuntu-24.04
-    if: ${{ (always() && !cancelled() && !failure())
-      && needs.publish.result == 'success'
-      && (!contains(github.event_name, 'pull_request') || (github.event.action == 'labeled' && github.event.label.name == 'prebuilt'))
-      && (fromJSON(vars.DEV_FEEDBACK_NOTIFICATION_BRANCHES_V2)[github.head_ref || github.ref_name] != null) }}
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Prepare notification message
-        id: message
-        run: |
-          TEMPLATE='${{ vars.DISCOURSE_GENERAL_UPDATE_NOTICE }}'
-          export VERSION="${{ needs.prepare_strategy.outputs.version }}"
-          export branch_name="${{ env.SOURCE_BRANCH }}"
-          export new_branch="${{ needs.prepare_strategy.outputs.new_branch }}"
-          export commit_sha="${{ github.sha }}"
-          export commit_short_sha="${{ github.sha }}"
-          export commit_short_sha="${commit_short_sha:0:7}"
-          export extra_version_identifier="${{ needs.prepare_strategy.outputs.extra_version_identifier || github.run_number }}"
-          export PUBLIC_REPO_URL="${{ env.PUBLIC_REPO_URL }}"
-
-          MESSAGE=$(cat << 'EOF' | envsubst
-          ${{ vars.DISCOURSE_GENERAL_UPDATE_NOTICE }}
-          EOF
-          )
-
-          {
-            echo 'content<<EOFMARKER'
-            echo "$MESSAGE"
-            echo 'EOFMARKER'
-          } >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Post to Discourse
-        uses: ./.github/workflows/post-to-discourse
-        with:
-          discourse-url: ${{ vars.DISCOURSE_URL }}
-          api-key: ${{ secrets.DISCOURSE_API_KEY }}
-          api-username: "system"
-          topic-id: ${{ fromJSON(vars.DEV_FEEDBACK_NOTIFICATION_BRANCHES_V2)[github.head_ref || github.ref_name].topic_id }}
-          message: ${{ steps.message.outputs.content }}
-
-  manage-pr-labels:
-    name: Remove prebuilt label
-    runs-on: ubuntu-latest
-    if: (always() && contains(github.event_name, 'pull_request') && (github.event.action == 'labeled' && github.event.label.name == 'prebuilt'))
-    env:
-      LABEL: prebuilt
-    steps:
-      - name: Remove trust-fork-pr label if present
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prNumber = context.payload.pull_request.number;
-
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-              name: process.env.LABELf
-            });
-
-            console.log(`Removed '${process.env.LABEL}' label from PR #${prNumber}`);


### PR DESCRIPTION
## What

Adapts `sunnypilot-build-prebuilt.yaml` so it builds and publishes prebuilt release branches on this repo (zoompilot/zoompilot), instead of pushing back to sunnypilot/sunnypilot.

## Changes

- **Triggers → manual only** (`workflow_dispatch`). Drops the dead `push: [master, master-dev]` and `pull_request_target` triggers (those branches do not exist here).
- **Fix push URL** (the actual fork blocker): `publish.sh` was invoked with `github.com/sunnypilot/sunnypilot.git`, which fails (no write access). Now hardcoded to `github.com/zoompilot/zoompilot.git`. The fork's own `GITHUB_TOKEN` has write access to its own repo.
- **Drop jobs** that are sunnypilot-specific or need extra config:
  - `validate_tests` (waited for `tests.yaml`)
  - `notify` (posted to Discourse; needs DISCOURSE_* secrets/templates)
  - `manage-pr-labels` (PR-label cleanup; only relevant with the removed PR trigger)
- **Simplify** `build.if` / `publish.if` accordingly.
- **`PUBLIC_REPO_URL`** → `zoompilot/zoompilot` (tidy-up; only the dropped `notify` job used it).

## Unchanged (correct as-is)

- `prepare_strategy` fallback: with no `DEPLOY_STRATEGY` variable set, a source branch auto-publishes to `<branch>-prebuilt` (e.g. `develop` → `develop-prebuilt`). Zero config required.
- `runs-on: [self-hosted, tici]`: label-matched, not hardware-matched. A tizi (c3x) or mici (c4) device registered via `release/ci/install_github_runner.sh` (which sets `--labels "tici"`) satisfies it. The build is device-generic aarch64 (`/TICI` marker), so one prebuilt branch serves both c3x and c4.
- `scons --minimal` build steps, `openpilot/...` paths, `--chown=comma:comma`, `secrets.GITHUB_TOKEN`.

## Prerequisite to run

A self-hosted runner labeled `tici` must be registered on this repo (none today). Register a c3x or c4 device:

```
bash release/ci/install_github_runner.sh <REGISTRATION_TOKEN> --repo https://github.com/zoompilot/zoompilot
```

Then: Actions → "sunnypilot prebuilt action" → Run workflow → branch `develop`. Result in ~20 min: a `develop-prebuilt` branch with compiled binaries + `prebuilt` marker.

## Validation

- YAML parsed and structurally validated (`triggers: workflow_dispatch`; `jobs: prepare_strategy, build, publish`).
- Identical to the workflow already tested on `mzdnick/zoompilot` except the two repo URLs point here.