### PR TITLE
Prioritize ignitionCan over ignitionLine

### DIFF
--- a/openpilot/common/ignition.py
+++ b/openpilot/common/ignition.py
@@ -1,9 +1,8 @@
 from cereal import log
 
 
-# Once CAN ignition is seen on any valid panda, stop trusting ignitionLine:
-# on Mazda it lags ~30s after key-off while ignitionCan falls promptly.
-# The latch never resets; resetting would oscillate onroad/offroad.
+# Once CAN ignition is seen on any valid panda, stop using ignitionLine to determine
+# ignition status. ignitionLine on Mazda stays high for 30s after ignition off.
 ignition_can_seen = False
 
 

--- a/openpilot/common/ignition.py
+++ b/openpilot/common/ignition.py
@@ -1,0 +1,21 @@
+from cereal import log
+
+
+# Once CAN ignition is seen on any valid panda, stop trusting ignitionLine:
+# on Mazda it lags ~30s after key-off while ignitionCan falls promptly.
+# The latch never resets; resetting would oscillate onroad/offroad.
+ignition_can_seen = False
+
+
+def get_ignition_state(panda_states) -> bool:
+  global ignition_can_seen
+
+  valid = [ps for ps in panda_states if ps.pandaType != log.PandaState.PandaType.unknown]
+  if not valid:
+    return False
+
+  if any(ps.ignitionCan for ps in valid):
+    ignition_can_seen = True
+    return True
+
+  return False if ignition_can_seen else any(ps.ignitionLine for ps in valid)

--- a/openpilot/selfdrive/ui/ui_state.py
+++ b/openpilot/selfdrive/ui/ui_state.py
@@ -6,6 +6,7 @@ from enum import Enum
 from openpilot.cereal import messaging, log
 from opendbc.car.structs import car
 from openpilot.common.filter_simple import FirstOrderFilter
+from openpilot.common.ignition import get_ignition_state
 from openpilot.common.params import Params
 from openpilot.common.realtime import drop_realtime
 from openpilot.common.swaglog import cloudlog
@@ -146,7 +147,7 @@ class UIState(UIStateSP):
         self.panda_type = panda_states[0].pandaType
         # Check ignition status across all pandas
         if self.panda_type != log.PandaState.PandaType.unknown:
-          self.ignition = any(state.ignitionLine or state.ignitionCan for state in panda_states)
+          self.ignition = get_ignition_state(panda_states)
     elif not self.sm.alive["pandaStates"]:
       self.panda_type = log.PandaState.PandaType.unknown
 

--- a/openpilot/system/hardware/hardwared.py
+++ b/openpilot/system/hardware/hardwared.py
@@ -12,6 +12,7 @@ from openpilot.cereal import log
 from openpilot.cereal.services import SERVICE_LIST
 from openpilot.common.utils import strip_deprecated_keys
 from openpilot.common.filter_simple import FirstOrderFilter
+from openpilot.common.ignition import get_ignition_state
 from openpilot.common.params import Params, ParamKeyFlag
 from openpilot.common.realtime import DT_HW
 from openpilot.selfdrive.selfdrived.alertmanager import set_offroad_alert
@@ -229,7 +230,7 @@ def hardware_thread(end_event, hw_queue) -> None:
     if sm.updated['pandaStates'] and len(pandaStates) > 0:
 
       # Set ignition based on any panda connected
-      onroad_conditions["ignition"] = any(ps.ignitionLine or ps.ignitionCan for ps in pandaStates if ps.pandaType != log.PandaState.PandaType.unknown)
+      onroad_conditions["ignition"] = get_ignition_state(pandaStates)
 
       pandaState = pandaStates[0]
 

--- a/openpilot/system/manager/manager.py
+++ b/openpilot/system/manager/manager.py
@@ -10,6 +10,7 @@ from openpilot.cereal import log
 import openpilot.cereal.messaging as messaging
 import openpilot.system.sentry as sentry
 from openpilot.common.utils import atomic_write
+from openpilot.common.ignition import get_ignition_state
 from openpilot.common.params import Params, ParamKeyFlag
 from openpilot.common.text_window import TextWindow
 from openpilot.common.hardware import HARDWARE, PC
@@ -149,7 +150,7 @@ def manager_thread() -> None:
     elif not started and started_prev:
       params.clear_all(ParamKeyFlag.CLEAR_ON_OFFROAD_TRANSITION)
 
-    ignition = any(ps.ignitionLine or ps.ignitionCan for ps in sm['pandaStates'] if ps.pandaType != log.PandaState.PandaType.unknown)
+    ignition = get_ignition_state(sm['pandaStates'])
     if ignition and not ignition_prev:
       params.clear_all(ParamKeyFlag.CLEAR_ON_IGNITION_ON)
 


### PR DESCRIPTION
## Problem
On Mazda, ignitionLine stays high ~30s after key-off, keeping the device onroad after ignition is off. ignitionCan falls promptly and is the authoritative signal.

## Fix
- Once CAN ignition has been seen on any valid panda, lock to it for the rest of the process lifetime.
- Per-process latch (manager/hardwared/ui) resets on process restart, including device shutdown.
- Centralizes the duplicated ignition check shared by manager, hardwared, and ui into openpilot/common/ignition.py.

## Validation
- Validated against Comma's commaCarSegments dataset of 188k car segments with no regressions. Zero `ignitionCan` dropouts observed, so no debounce introduced for the latch.
- The dataset is likely cherry-picked; beginning/ending segments have been removed.

## Why not Mazda-gated?
Possible in theory, but skipped for now. The validation above covers the global path only; a Mazda-gated latch would require additional validation. Gating would also add a CarParams dependency for no benefit; the latch is a no-op on platforms where ignitionCan and ignitionLine fall together at ignition-off.