### PR TITLE
ui: restore zoompilot home screen branding

### DIFF
--- a/openpilot/selfdrive/ui/sunnypilot/layouts/home.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/home.py
@@ -51,7 +51,7 @@ class HomeLayoutSP(HomeLayout):
     version_right = self.header_rect.x + self.header_rect.width
     version_left = version_right - version_text_width
 
-    brand = "sunnypilot"
+    brand = "zoompilot"
     description = self.params.get("UpdaterCurrentDescription") or ""
 
     desc_width = 0

--- a/openpilot/selfdrive/ui/sunnypilot/mici/layouts/home.py
+++ b/openpilot/selfdrive/ui/sunnypilot/mici/layouts/home.py
@@ -12,4 +12,4 @@ from openpilot.system.ui.widgets.label import UnifiedLabel
 class MiciHomeLayoutSP(MiciHomeLayout):
   def __init__(self):
     super().__init__()
-    self._openpilot_label = UnifiedLabel("sunnypilot", font_size=88, font_weight=FontWeight.AUDIOWIDE, max_width=480, wrap_text=False)
+    self._openpilot_label = UnifiedLabel("zoompilot", font_size=88, font_weight=FontWeight.AUDIOWIDE, max_width=480, wrap_text=False)


### PR DESCRIPTION
## Problem

After the sunnypilot master sync (`2966c5cf69`), the offroad home screen shows "sunnypilot" instead of "zoompilot". This affects both tici/tizi and mici devices.

## Cause

The sync brought upstream sunnypilot [PR #1895](https://github.com/sunnypilot/sunnypilot/pull/1895) (`6909aa95ff`, "ui: use sunnypilot and sunnylink branding fonts"). That PR added two new classes which draw the brand string themselves:

- `openpilot/selfdrive/ui/sunnypilot/layouts/home.py` — `HomeLayoutSP._render_header()` hardcodes `brand = "sunnypilot"`
- `openpilot/selfdrive/ui/sunnypilot/mici/layouts/home.py` — `MiciHomeLayoutSP` rebuilds `_openpilot_label` with `UnifiedLabel("sunnypilot", ...)`

Both `layouts/main.py` files import these classes under `gui_app.sunnypilot_ui()` as `HomeLayout` / `MiciHomeLayout`, so they replace the base classes at runtime. zoompilot's "zoompilot" strings live in those base classes (`openpilot/selfdrive/ui/layouts/home.py:231`, `openpilot/selfdrive/ui/mici/layouts/home.py:159`), which the new subclasses bypass. The merge raised no conflict: PR #1895 only added new files and one import line per `main.py`.

## Fix

Rebrand the two SP mirror files to "zoompilot". Two changed lines, one per file. Font, size, and layout stay as upstream set them.

## Note for future syncs

Any sunnypilot sync that touches these two mirror files can silently flip the brand back to "sunnypilot". If this recurs, the follow-up is a single brand constant shared by all home layout files, so a sync conflicts loudly instead.

## AI Usage

Disclaimer: GLM-5.3 was used to help develop, debug, and document this submission. All changes were reviewed and validated by a human.