### PR TITLE
ui: zoompilot branding for screensaver text

### DIFF
--- a/openpilot/system/ui/sunnypilot/widgets/screen_saver.py
+++ b/openpilot/system/ui/sunnypilot/widgets/screen_saver.py
@@ -30,7 +30,7 @@ class ScreenSaverSP(Widget):
     self._hue = 150
     self.color = rl.color_from_hsv(self._hue, 1, 1)
 
-    self.text = "sunnypilot"
+    self.text = "zoompilot"
     self.font_size = 50 if self._is_mici else 200
     self._start_time = None
     self._dismiss = False


### PR DESCRIPTION
## Problem

The screensaver from the sunnypilot sync bounces the text "sunnypilot" around the screen. On zoompilot devices it should say "zoompilot".

## Cause

Upstream sunnypilot [PR #1551](https://github.com/sunnypilot/sunnypilot/pull/1551) (commit `2a16b0fbba`, "ui: screensaver") added `ScreenSaverSP` in `openpilot/system/ui/sunnypilot/widgets/screen_saver.py`. The widget hardcodes the brand string in `__init__` (`self.text = "sunnypilot"`). The offroad UI state pushes this widget when `ScreenSaverEnabled` is set and the device goes idle, so devices show the upstream brand.

## Fix

Change the string to "zoompilot". One changed line. Font (AUDIOWIDE), size, motion, and color behavior stay as upstream set them.

## Note for future syncs

This file comes from sunnypilot, so a future sync can overwrite this line and flip the brand back. Check the brand string in `screen_saver.py` after each sync, together with the home layout files from #4.

---

**Disclaimer:** GLM-5.3 by Z.ai was used to help develop, debug, and document this submission. All changes were reviewed and validated by a human.
