### PR TITLE
ui: zoompilot branding for settings and alerts + README credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ Something misbehaving on your Mazda? Open an issue on the [tracker](https://gith
 
 ## credits
 
-zoompilot stands on [sunnypilot](https://github.com/sunnypilot/sunnypilot), which stands on [openpilot](https://github.com/commaai/openpilot) by comma.ai. Nearly everything here rides on their work. Star their repos and read their docs.
+zoompilot stands on [sunnypilot](https://github.com/sunnypilot/sunnypilot), which stands on [openpilot](https://github.com/commaai/openpilot) by comma.ai. Most of the code here is theirs. Remote access and dashboards come from [sunnylink](https://www.sunnylink.ai/), a free service paid for by the sunnypilot project. To support them: [sponsor sunnypilot](https://github.com/sponsors/sunnyhaibin), or [buy hardware from comma](https://comma.ai/shop).
+
+---
 
 These features would work on other vehicles and could be upstreamed into sunnypilot or openpilot. I'm slowly working on that, but it's easier to share my own fork in the meantime.
 

--- a/openpilot/selfdrive/selfdrived/alerts_offroad.json
+++ b/openpilot/selfdrive/selfdrived/alerts_offroad.json
@@ -4,12 +4,12 @@
     "severity": 0
   },
   "Offroad_ConnectivityNeededPrompt": {
-    "text": "Immediately connect to the internet to check for updates. If you do not connect to the internet, sunnypilot won't engage in %1",
+    "text": "Immediately connect to the internet to check for updates. If you do not connect to the internet, zoompilot won't engage in %1",
     "severity": 0,
     "_comment": "Set extra field to number of days"
   },
   "Offroad_ConnectivityNeeded": {
-    "text": "Connect to internet to check for updates. sunnypilot won't automatically start until it connects to internet to check for updates.",
+    "text": "Connect to internet to check for updates. zoompilot won't automatically start until it connects to internet to check for updates.",
     "severity": 1
   },
   "Offroad_UpdateFailed": {
@@ -26,11 +26,11 @@
     "severity": 1
   },
   "Offroad_CarUnrecognized": {
-    "text": "sunnypilot was unable to identify your car. Your car is either unsupported or its ECUs are not recognized. Please select your vehicle manually at https://www.sunnylink.ai/. Need help? Visit https://community.sunnypilot.ai/",
+    "text": "zoompilot was unable to identify your car. Your car is either unsupported or its ECUs are not recognized. Please select your vehicle manually at https://www.sunnylink.ai/. Need help? Visit https://community.sunnypilot.ai/",
     "severity": 0
   },
   "Offroad_Recalibration": {
-    "text": "sunnypilot detected a change in the device's mounting position. Ensure the device is fully seated in the mount and the mount is firmly secured to the windshield.",
+    "text": "zoompilot detected a change in the device's mounting position. Ensure the device is fully seated in the mount and the mount is firmly secured to the windshield.",
     "severity": 0
   },
   "Offroad_OSMUpdateRequired": {

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/settings/cruise.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/settings/cruise.py
@@ -20,14 +20,14 @@ class PanelType(IntEnum):
   SLA = 1
 
 
-ICBM_DESC = tr_noop("When enabled, sunnypilot will attempt to manage the built-in cruise control buttons " +
+ICBM_DESC = tr_noop("When enabled, zoompilot will attempt to manage the built-in cruise control buttons " +
                     "by emulating button presses for limited longitudinal control.")
 ICMB_UNAVAILABLE = tr_noop("Intelligent Cruise Button Management is currently unavailable on this platform.")
-ICMB_UNAVAILABLE_LONG_AVAILABLE = tr_noop("Disable the sunnypilot Longitudinal Control (alpha) toggle to allow Intelligent Cruise Button Management.")
-ICMB_UNAVAILABLE_LONG_UNAVAILABLE = tr_noop("sunnypilot Longitudinal Control is the default longitudinal control for this platform.")
+ICMB_UNAVAILABLE_LONG_AVAILABLE = tr_noop("Disable the zoompilot Longitudinal Control (alpha) toggle to allow Intelligent Cruise Button Management.")
+ICMB_UNAVAILABLE_LONG_UNAVAILABLE = tr_noop("zoompilot Longitudinal Control is the default longitudinal control for this platform.")
 
 ACC_ENABLED_DESCRIPTION = tr_noop("Enable custom Short & Long press increments for cruise speed increase/decrease.")
-ACC_NOLONG_DESCRIPTION = tr_noop("This feature can only be used with sunnypilot longitudinal control enabled.")
+ACC_NOLONG_DESCRIPTION = tr_noop("This feature can only be used with zoompilot longitudinal control enabled.")
 ACC_PCMCRUISE_DISABLED_DESCRIPTION = tr_noop("This feature is not supported on this platform due to vehicle limitations.")
 ONROAD_ONLY_DESCRIPTION = tr_noop("Start the vehicle to check vehicle compatibility.")
 
@@ -92,7 +92,7 @@ class CruiseLayout(Widget):
 
     self.dec_toggle = toggle_item_sp(
       title=tr("Enable Dynamic Experimental Control"),
-      description=tr("Enable toggle to allow the model to determine when to use sunnypilot ACC or sunnypilot End to End Longitudinal."),
+      description=tr("Enable toggle to allow the model to determine when to use zoompilot ACC or zoompilot End to End Longitudinal."),
       param="DynamicExperimentalControl")
 
     items = [

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/settings/developer.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/settings/developer.py
@@ -37,7 +37,7 @@ class DeveloperLayoutSP(DeveloperLayout):
 
   def _initialize_items(self):
     self.show_advanced_controls = toggle_item_sp(tr("Show Advanced Controls"),
-                                                 tr("Toggle visibility of advanced sunnypilot controls.<br>This only changes the visibility of the toggles; " +
+                                                 tr("Toggle visibility of advanced zoompilot controls.<br>This only changes the visibility of the toggles; " +
                                                     "it does not change the actual enabled/disabled state."), param="ShowAdvancedControls")
 
     self.enable_github_runner_toggle = toggle_item_sp(tr("GitHub Runner Service"), tr("Enables or disables the GitHub runner service."),
@@ -50,7 +50,7 @@ class DeveloperLayoutSP(DeveloperLayout):
 
     self.prebuilt_toggle = toggle_item_sp(tr("Quickboot Mode"), "", param="QuickBootToggle", callback=self._on_prebuilt_toggled)
 
-    self.error_log_btn = button_item(tr("Error Log"), tr("VIEW"), tr("View the error log for sunnypilot crashes."), callback=self._on_error_log_clicked)
+    self.error_log_btn = button_item(tr("Error Log"), tr("VIEW"), tr("View the error log for zoompilot crashes."), callback=self._on_error_log_clicked)
 
     self.items: list = [self.show_advanced_controls, self.enable_github_runner_toggle, self.enable_copyparty_toggle, self.prebuilt_toggle, self.error_log_btn,]
 

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/settings/device.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/settings/device.py
@@ -161,7 +161,7 @@ class DeviceLayoutSP(DeviceLayout):
         ))
 
     gui_app.push_widget(ConfirmDialog(
-      text=tr("Are you sure you want to reset all sunnypilot settings to default? Once the settings are reset, there is no going back."),
+      text=tr("Are you sure you want to reset all zoompilot settings to default? Once the settings are reset, there is no going back."),
       confirm_text=tr("Reset"), callback=_second_confirm
     ))
 

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/settings/steering.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/settings/steering.py
@@ -38,7 +38,7 @@ class SteeringLayout(Widget):
 
   def _initialize_items(self):
     self._mads_base_desc = tr("Enable the beloved MADS feature. " +
-                              "Disable toggle to revert back to stock sunnypilot engagement/disengagement.")
+                              "Disable toggle to revert back to stock zoompilot engagement/disengagement.")
     self._mads_limited_desc = tr("This platform supports limited MADS settings.")
     self._mads_full_desc = tr("This platform supports all MADS settings.")
     self._mads_check_compat_desc = tr("Start the vehicle to check vehicle compatibility.")
@@ -84,7 +84,7 @@ class SteeringLayout(Widget):
     self._torque_control_toggle = toggle_item_sp(
       param="EnforceTorqueControl",
       title=lambda: tr("Enforce Torque Lateral Control"),
-      description=lambda: tr("Enable this to enforce sunnypilot to steer with Torque lateral control."),
+      description=lambda: tr("Enable this to enforce zoompilot to steer with Torque lateral control."),
     )
     self._torque_customization_button = simple_button_item_sp(
       button_text=lambda: tr("Customize Torque Params"),

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/settings/steering_sub_layouts/mads_settings.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/settings/steering_sub_layouts/mads_settings.py
@@ -103,7 +103,7 @@ class MadsSettingsLayout(Widget):
     return False
 
   def _update_steering_mode_description(self, button_index: int):
-    base_desc = tr("Choose how Automatic Lane Centering (ALC) behaves after the brake pedal is manually pressed in sunnypilot.")
+    base_desc = tr("Choose how Automatic Lane Centering (ALC) behaves after the brake pedal is manually pressed in zoompilot.")
     result = base_desc + "<br><br>"
     for opt in MADS_STEERING_MODE_OPTIONS:
       desc = "<b>" + opt[1] + "</b>" if button_index == MADS_STEERING_MODE_OPTIONS.index(opt) else opt[1]

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/settings/sunnylink.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/settings/sunnylink.py
@@ -176,7 +176,7 @@ class SunnylinkLayout(Widget):
     )
     self._sunnylink_uploader_toggle = toggle_item_sp(
       title=tr("Enable sunnylink uploader (infrastructure test)"),
-      description=tr("Enable sunnylink uploader to allow sunnypilot to upload your driving data to sunnypilot servers. ") +
+      description=tr("Enable sunnylink uploader to allow zoompilot to upload your driving data to sunnylink servers. ") +
                   tr("(Only for highest tiers, and does NOT bring ANY benefit to you yet. We are just testing data volume.)"),
       param="EnableSunnylinkUploader"
     )
@@ -223,13 +223,13 @@ class SunnylinkLayout(Widget):
       gui_app.push_widget(self._sunnylink_pairing_dialog)
 
   def _handle_backup_btn(self):
-    backup_dialog = ConfirmDialog(text=tr("Are you sure you want to backup your current sunnypilot settings?"), confirm_text="Backup",
+    backup_dialog = ConfirmDialog(text=tr("Are you sure you want to backup your current zoompilot settings?"), confirm_text="Backup",
                                   callback=self._backup_handler)
     gui_app.push_widget(backup_dialog)
 
   def _handle_restore_btn(self):
     self._restore_btn.set_enabled(False)
-    restore_dialog = ConfirmDialog(text=tr("Are you sure you want to restore the last backed up sunnypilot settings?"),
+    restore_dialog = ConfirmDialog(text=tr("Are you sure you want to restore the last backed up zoompilot settings?"),
                                    confirm_text="Restore", callback=self._restore_handler)
     gui_app.push_widget(restore_dialog)
 

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/settings/visuals.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/settings/visuals.py
@@ -13,8 +13,8 @@ from openpilot.system.ui.widgets import Widget
 
 CHEVRON_INFO_DESCRIPTION = {
   "enabled": tr_noop("Display useful metrics below the chevron that tracks the lead car " +
-                     "only applicable to cars with sunnypilot longitudinal control."),
-  "disabled": tr_noop("This feature requires sunnypilot longitudinal control to be available.")
+                     "only applicable to cars with zoompilot longitudinal control."),
+  "disabled": tr_noop("This feature requires zoompilot longitudinal control to be available.")
 }
 
 


### PR DESCRIPTION
## Summary

Replace "sunnypilot" with "zoompilot" in user-facing text only. Sunnylink and sponsor text stay unchanged. Add sponsor and shop links to the README credits.

- 20 strings swapped "sunnypilot" → "zoompilot": four offroad alerts (`alerts_offroad.json`) and settings text in the cruise, steering, device, sunnylink, visuals, developer, and MADS layouts.
- README credits now name sunnylink as a free service paid for by the sunnypilot project, and link the sunnypilot sponsor page and the comma shop.

## Kept as "sunnypilot" on purpose

- The sunnylink sponsor strings (the settings sponsor pitch and both pairing dialog labels).
- The vehicle-brand longitudinal control texts (`toyota.py`, `hyundai.py`) and the onboarding sunnylink page.
- All `community.sunnypilot.ai` and `sunnylink.ai` links stay unchanged.

## Notes

- Locale `.po` files key on the English strings. Swapped strings fall back to English until the keys are updated (same as #4 and #5).
- This change exists to reduce user confusion, not to claim credit for sunnypilot's work. If this fork is useful to you, please consider [sponsoring Sunnypilot](https://github.com/sponsors/sunnyhaibin).

## AI Usage

Disclaimer: GLM-5.3 by Z.ai was used to help develop, debug, and document this submission. All changes were reviewed and validated by a human.