### PR TITLE
updated: make the offline connectivity nags unreachable

### DIFF
--- a/openpilot/system/updated/updated.py
+++ b/openpilot/system/updated/updated.py
@@ -29,12 +29,13 @@ FINALIZED = os.path.join(STAGING_ROOT, "finalized")
 
 OVERLAY_INIT = Path(os.path.join(BASEDIR, ".overlay_init"))
 
+# unreachable for any device: both connectivity alerts stay permanently off
 # do not allow to engage after this many hours onroad and this many routes
-HOURS_NO_CONNECTIVITY_MAX = 27
-ROUTES_NO_CONNECTIVITY_MAX = 84
+HOURS_NO_CONNECTIVITY_MAX = 1000000
+ROUTES_NO_CONNECTIVITY_MAX = 1000000
 # send an offroad prompt after this many hours onroad and this many routes
-HOURS_NO_CONNECTIVITY_PROMPT = 23
-ROUTES_NO_CONNECTIVITY_PROMPT = 80
+HOURS_NO_CONNECTIVITY_PROMPT = 1000000
+ROUTES_NO_CONNECTIVITY_PROMPT = 1000000
 
 
 class UserRequest:


### PR DESCRIPTION
## Problem

After 23 onroad hours / 80 routes without a successful update check, the
updater sets `Offroad_ConnectivityNeededPrompt`; at 27 hours / 84 routes it
sets `Offroad_ConnectivityNeeded`, which also blocks going onroad through
hardwared's `up_to_date` condition. Devices driven offline get locked out.

## Fix

Raise the four thresholds to 1,000,000. Both alerts need onroad hours AND
routes past them, so neither can fire in a device's lifetime. The gate now
reads a param that is never set. Updates still install when online;
`Offroad_UpdateFailed` is untouched. Constants-only on purpose: `set_params`
keeps its upstream shape, so sunnypilot syncs merge clean.

## Validation

`ruff check` and `py_compile` clean; no other readers of the constants.

## AI Usage

Disclaimer: GLM-5.3 by Z.ai was used to help develop, debug, and document
this submission. All changes were reviewed and validated by a human.