### PR TITLE
agnos: init the kernel through git submodule

### DIFF
--- a/.github/workflows/zoompilot-agnos-tici-boot.yaml
+++ b/.github/workflows/zoompilot-agnos-tici-boot.yaml
@@ -1,0 +1,263 @@
+name: zoompilot agnos tici boot
+
+# Build the AGNOS boot partition for the comma three (tici) and publish it.
+#
+# comma deleted comma_tici.dts from agnos-kernel-sdm845 in b90695f101ba, so every
+# AGNOS from 13 on has no device tree for the comma three and will not boot one.
+# This workflow builds comma's kernel at a pinned commit with that DTS restored,
+# packages the boot image the way agnos-builder's package_ota.py does, publishes
+# the .img.xz as a release asset, and opens a PR pointing the boot entry of
+# openpilot/common/hardware/comma/tici_agnos.json at it. Every other partition on
+# a comma three stays on comma's official images.
+#
+# This is not comma's official boot image and cannot be. See docs/agnos-tici-boot.md
+# for what that means, how to verify the result, and how to recover a device that
+# will not boot after flashing one.
+#
+# Nothing here has been run on a physical comma three.
+
+on:
+  workflow_dispatch:
+    inputs:
+      kernel_commit:
+        description: commaai/agnos-kernel-sdm845 commit to build
+        default: c368754c26c7b9659de187addc6cccedc6cfb0a0
+        required: true
+      agnos_builder_commit:
+        description: commaai/agnos-builder commit supplying build_kernel.sh, the toolchain and the signing key
+        default: 8f7207a4f083ce3215f893a01b74613c507cc4bc
+        required: true
+      runner:
+        description: runner label. ubuntu-latest cross compiles from x86_64; ubuntu-24.04-arm builds natively like comma's CI
+        default: ubuntu-latest
+        required: true
+      release_tag:
+        description: tag to publish the asset under. Blank means agnos-tici-boot-<run number>
+        default: ''
+      open_pr:
+        description: open a PR updating the boot entry in tici_agnos.json
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  build:
+    name: build tici boot image
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 180
+
+    steps:
+      - name: Check out zoompilot
+        uses: actions/checkout@v4
+        with:
+          path: zoompilot
+          lfs: false
+          submodules: false
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL || true
+          df -h /
+
+      # LFS carries the cross toolchain (tools/aarch64-linux-gnu-gcc.tar.gz) and the
+      # firmware images. extract_tools.sh pulls everything if any pointer is left, so
+      # take the whole thing up front rather than fighting it.
+      - name: Check out agnos-builder
+        uses: actions/checkout@v4
+        with:
+          repository: commaai/agnos-builder
+          ref: ${{ inputs.agnos_builder_commit }}
+          path: agnos-builder
+          lfs: true
+          submodules: false
+
+      # Shallow, so we do not pull the whole kernel history onto a runner disk.
+      # github.com serves fetch-by-sha, so any commit works, not just a branch tip.
+      - name: Check out the kernel at the pinned commit
+        working-directory: agnos-builder
+        run: |
+          set -e
+          rm -rf agnos-kernel-sdm845
+          mkdir agnos-kernel-sdm845
+          cd agnos-kernel-sdm845
+          git init -q .
+          git remote add origin https://github.com/commaai/agnos-kernel-sdm845.git
+          git fetch --depth 1 origin ${{ inputs.kernel_commit }}
+          git checkout -q --detach FETCH_HEAD
+          git log -1 --format='kernel %H %ci %s'
+
+      # build_kernel.sh re-clones the submodule if it looks uninitialized. It does not
+      # here, because the directory now has its own .git, but a silent re-clone would
+      # throw away the patch below, so fail loudly instead of trusting it.
+      - name: Confirm build_kernel.sh will not re-clone the kernel
+        working-directory: agnos-builder
+        run: |
+          status=$(git submodule status --cached agnos-kernel-sdm845/ || true)
+          echo "submodule status: $status"
+          case "$status" in
+            -*) echo "::error::kernel checkout looks uninitialized to git; build_kernel.sh would re-clone it and drop the DTS patch"; exit 1 ;;
+          esac
+
+      - name: Restore comma_tici.dts
+        working-directory: agnos-builder/agnos-kernel-sdm845
+        run: |
+          set -e
+          git apply -v "$GITHUB_WORKSPACE/zoompilot/scripts/agnos/restore-comma_tici-dts.patch"
+          test -f arch/arm64/boot/dts/qcom/comma_tici.dts
+          grep -q 'comma_tici.dtb' arch/arm64/boot/dts/qcom/Makefile
+          # tici_defconfig leaves CONFIG_BUILD_ARM64_APPENDED_DTB_IMAGE_NAMES empty, which
+          # makes arch/arm64/boot/Makefile append every dtb it finds. If a kernel bump ever
+          # sets a name list, the dtb would build but never reach Image-dtb.
+          grep -q 'CONFIG_BUILD_ARM64_APPENDED_DTB_IMAGE_NAMES=""' arch/arm64/configs/tici_defconfig \
+            || { echo "::error::tici_defconfig now names the appended dtbs; comma_tici.dtb must be added to that list"; exit 1; }
+
+      - name: Restore ccache
+        uses: actions/cache@v4
+        with:
+          path: agnos-builder/.ccache
+          key: agnos-kernel-${{ inputs.kernel_commit }}-${{ runner.arch }}-${{ github.run_id }}
+          restore-keys: |
+            agnos-kernel-${{ inputs.kernel_commit }}-${{ runner.arch }}-
+            agnos-kernel-
+
+      - name: Build the kernel
+        working-directory: agnos-builder
+        env:
+          CCACHE_DIR: ${{ github.workspace }}/agnos-builder/.ccache
+          CCACHE_MAXSIZE: 5G
+        run: ./build_kernel.sh
+
+      # Image-dtb is the uncompressed kernel with every built dtb concatenated onto it,
+      # and boot.img is that plus the mkbootimg header and comma's LE signature. The
+      # bootloader picks a dtb by qcom,msm-id and board-id, so all three comma boards
+      # ride in one image and the comma three simply had no entry to pick.
+      - name: Confirm the tici device tree is in the image
+        working-directory: agnos-builder
+        run: |
+          set -e
+          dtb=agnos-kernel-sdm845/out/arch/arm64/boot/dts/qcom/comma_tici.dtb
+          test -f "$dtb" || { echo "::error::comma_tici.dtb was not built"; exit 1; }
+          for board in tici tizi mici; do
+            if strings -a output/boot.img | grep -qx "comma $board"; then
+              echo "boot.img carries the $board device tree"
+            elif [ "$board" = tici ]; then
+              echo "::error::boot.img does not contain the comma tici device tree"; exit 1
+            else
+              echo "::warning::boot.img does not contain the comma $board device tree"
+            fi
+          done
+          ls -l output/boot.img
+
+      - name: Package and hash
+        id: package
+        working-directory: agnos-builder
+        run: |
+          set -e
+          ENTRY=$GITHUB_WORKSPACE/entry.json
+          NAME=$(python3 "$GITHUB_WORKSPACE/zoompilot/scripts/agnos/manifest_entry.py" output/boot.img --xz-name)
+          # Single threaded on purpose. xz -T0 can emit concatenated streams, and agnos.py
+          # stops decompressing at the first stream end, which would truncate the flash.
+          # Compression level does not affect any manifest field; hash is of the plain image.
+          xz -9 -T1 -c output/boot.img > "$GITHUB_WORKSPACE/$NAME"
+          TAG="${{ inputs.release_tag }}"
+          [ -n "$TAG" ] || TAG="agnos-tici-boot-${{ github.run_number }}"
+          URL="https://github.com/${{ github.repository }}/releases/download/$TAG/$NAME"
+          python3 "$GITHUB_WORKSPACE/zoompilot/scripts/agnos/manifest_entry.py" output/boot.img \
+            --url "$URL" --verify-xz "$GITHUB_WORKSPACE/$NAME" -o "$ENTRY"
+          {
+            echo "asset=$NAME"
+            echo "tag=$TAG"
+            echo "url=$URL"
+          } | tee -a "$GITHUB_OUTPUT"
+
+      - name: Summarise
+        run: |
+          {
+            echo '## tici boot image'
+            echo
+            echo "- kernel \`${{ inputs.kernel_commit }}\` with \`comma_tici.dts\` restored"
+            echo "- agnos-builder \`${{ inputs.agnos_builder_commit }}\`"
+            echo "- built on \`${{ inputs.runner }}\`"
+            echo
+            echo 'Paste into the `boot` entry of `openpilot/common/hardware/comma/tici_agnos.json`:'
+            echo
+            echo '```json'
+            cat entry.json
+            echo '```'
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: tici-boot
+          path: |
+            ${{ steps.package.outputs.asset }}
+            entry.json
+            agnos-builder/output/boot.img
+          compression-level: 0
+
+      - name: Publish the release asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.package.outputs.tag }}
+          ASSET: ${{ steps.package.outputs.asset }}
+        run: |
+          set -e
+          cat > "$RUNNER_TEMP/notes.md" <<'EOF'
+          AGNOS boot partition for the comma three.
+
+          Kernel `KERNEL_COMMIT` from commaai/agnos-kernel-sdm845 with `comma_tici.dts` restored,
+          built with agnos-builder `BUILDER_COMMIT`.
+
+          This is not comma's official boot image and cannot be reproduced bit for bit against one.
+          Read `docs/agnos-tici-boot.md` before flashing it.
+          EOF
+          sed -i "s/KERNEL_COMMIT/${{ inputs.kernel_commit }}/; s/BUILDER_COMMIT/${{ inputs.agnos_builder_commit }}/" "$RUNNER_TEMP/notes.md"
+          if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
+            gh release create "$TAG" --repo "${{ github.repository }}" \
+              --title "AGNOS tici boot $TAG" \
+              --notes-file "$RUNNER_TEMP/notes.md"
+          fi
+          gh release upload "$TAG" "$ASSET" --repo "${{ github.repository }}" --clobber
+          curl -sIL "${{ steps.package.outputs.url }}" | grep -i '^\(HTTP/\|content-type\|content-length\)' || true
+
+      - name: Open a PR updating the tici manifest
+        if: ${{ inputs.open_pr }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        working-directory: zoompilot
+        run: |
+          set -e
+          BRANCH="agnos-tici-boot/${{ github.run_id }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          python3 scripts/agnos/update_manifest.py \
+            openpilot/common/hardware/comma/tici_agnos.json "$GITHUB_WORKSPACE/entry.json" \
+            --comment "kernel ${{ inputs.kernel_commit }} with comma_tici.dts restored, agnos-builder ${{ inputs.agnos_builder_commit }}, built by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          git add openpilot/common/hardware/comma/tici_agnos.json
+          SHORT=$(echo "${{ inputs.kernel_commit }}" | cut -c1-9)
+          git commit -m "agnos: tici boot image from kernel $SHORT"
+          git push origin "$BRANCH"
+          cat > "$RUNNER_TEMP/pr.md" <<'EOF'
+          Boot partition for the comma three, built by [run RUN_ID](RUN_URL).
+
+          - kernel `KERNEL_COMMIT` with `comma_tici.dts` restored by `scripts/agnos/restore-comma_tici-dts.patch`
+          - agnos-builder `BUILDER_COMMIT`
+          - asset `ASSET_NAME`
+
+          Untested on hardware. Read `docs/agnos-tici-boot.md` before flashing anything.
+          EOF
+          sed -i \
+            -e "s/RUN_ID/${{ github.run_id }}/" \
+            -e "s#RUN_URL#${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#" \
+            -e "s/KERNEL_COMMIT/${{ inputs.kernel_commit }}/" \
+            -e "s/BUILDER_COMMIT/${{ inputs.agnos_builder_commit }}/" \
+            -e "s/ASSET_NAME/${{ steps.package.outputs.asset }}/" \
+            "$RUNNER_TEMP/pr.md"
+          gh pr create --base "${{ github.ref_name }}" --head "$BRANCH" \
+            --title "agnos: tici boot image from kernel $SHORT" \
+            --body-file "$RUNNER_TEMP/pr.md"

--- a/.github/workflows/zoompilot-agnos-tici-boot.yaml
+++ b/.github/workflows/zoompilot-agnos-tici-boot.yaml
@@ -80,13 +80,12 @@ jobs:
         working-directory: agnos-builder
         run: |
           set -e
-          rm -rf agnos-kernel-sdm845
-          mkdir agnos-kernel-sdm845
+          git submodule update --init --depth 1 agnos-kernel-sdm845
           cd agnos-kernel-sdm845
-          git init -q .
-          git remote add origin https://github.com/commaai/agnos-kernel-sdm845.git
-          git fetch --depth 1 origin ${{ inputs.kernel_commit }}
-          git checkout -q --detach FETCH_HEAD
+          if [ "$(git rev-parse HEAD)" != "${{ inputs.kernel_commit }}" ]; then
+            git fetch --depth 1 origin ${{ inputs.kernel_commit }}
+            git checkout -q --detach FETCH_HEAD
+          fi
           git log -1 --format='kernel %H %ci %s'
 
       # build_kernel.sh re-clones the submodule if it looks uninitialized. It does not

--- a/docs/agnos-tici-boot.md
+++ b/docs/agnos-tici-boot.md
@@ -1,0 +1,227 @@
+# The AGNOS boot image for the comma three
+
+`.github/workflows/zoompilot-agnos-tici-boot.yaml` builds the one AGNOS partition a comma three
+cannot take from comma, publishes it as a release asset, and fills in the `boot` entry of
+`openpilot/common/hardware/comma/tici_agnos.json`.
+
+**Nothing in this document has been run on a comma three.** The image has never been built, never
+been flashed and never been booted. Read [Recovery](#recovery) before you flash anything.
+
+## Why
+
+comma deleted `arch/arm64/boot/dts/qcom/comma_tici.dts` and its `Makefile` line from
+`commaai/agnos-kernel-sdm845` in `b90695f101ba` (2025-08-26). That commit changed exactly two files
+and nothing else.
+
+One kernel image serves all three SDM845 boards. `tici_defconfig` sets
+`CONFIG_BUILD_ARM64_APPENDED_DTB_IMAGE_NAMES=""`, which makes `arch/arm64/boot/Makefile` append
+*every* dtb it can find to `Image-dtb`, and the bootloader picks one by matching `qcom,msm-id` and
+`qcom,board-id`. Delete the comma three's dtb and the bootloader has nothing to match, so the
+kernel never gets a device tree and the board does not come up. AGNOS 12.8 is the last release
+built before the deletion and the last one that boots a comma three.
+
+Only `boot` is affected. `xbl`, `xbl_config`, `abl`, `aop`, `devcfg` and `system` are the same
+images on all three boards, so `tici_agnos.json` is comma's official manifest for the pinned AGNOS
+version with our `boot` entry swapped in. `AGNOS_VERSION` in `launch_env.sh` stays one value
+because `/VERSION` is written by the shared system image.
+
+## What the image actually is
+
+The AGNOS kernel at a pinned commit, with the deleted DTS restored, built and packaged exactly the
+way `agnos-builder/build_kernel.sh` does it:
+
+- cross compiled with `DEFCONFIG=tici_defconfig` inside comma's `Dockerfile.builder` container
+  (Ubuntu 20.04, python2, the Linaro `aarch64-linux-gnu` toolchain from `tools/`)
+- `Image-dtb` is the uncompressed `Image` with `comma_tici.dtb`, `comma_tizi.dtb`,
+  `comma_mici.dtb` and `comma_ultimate_provisioning.dtb` concatenated onto it
+- wrapped by `tools/mkbootimg` with comma's cmdline, 4096 byte pages, base `0x80000000`
+- signed with `vble-qti.key`, which is committed in the clear in agnos-builder, and the padded
+  signature appended
+
+The restoration lives in `scripts/agnos/restore-comma_tici-dts.patch`. It is version controlled
+rather than fetched at build time so a reviewer can read exactly what goes into the kernel. The
+`.dts` in it is byte-identical to the deleted file.
+
+### It is not comma's image, and it cannot be
+
+agnos-builder's public master last bumped its kernel submodule in May 2026. The kernel repo has
+commits through 2026-09-04, and openpilot pins AGNOS 19.7, cut 2026-09-01. comma therefore builds
+19.7 from something that is not fully reflected in public agnos-builder, and **we cannot reproduce
+comma's official 19.7 boot image bit for bit**. Ours is the AGNOS kernel at a pinned commit plus
+the tici DTB, paired with comma's official 19.7 userspace.
+
+Kernel to userspace coupling on AGNOS is loose (the system image ships no out-of-tree modules built
+against a specific `vermagic`), so the pairing is expected to work. Expected, not demonstrated.
+
+Both pins are workflow inputs. Raising `kernel_commit` is the intended way to track comma; the
+patch's `Makefile` hunk carries three lines of context and will need refreshing if a kernel bump
+adds or removes a board there.
+
+## Running the build
+
+Actions > *zoompilot agnos tici boot* > Run workflow, from the branch whose manifest you want
+updated.
+
+| input | default | what it does |
+|---|---|---|
+| `kernel_commit` | `c368754c26c7b9659de187addc6cccedc6cfb0a0` | the agnos-kernel-sdm845 commit to build. This is what agnos-builder master pins. |
+| `agnos_builder_commit` | `8f7207a4f083ce3215f893a01b74613c507cc4bc` | supplies `build_kernel.sh`, the container, `mkbootimg`, the toolchain and the signing key |
+| `runner` | `ubuntu-latest` | x86_64, cross compiles with the bundled Linaro toolchain. `ubuntu-24.04-arm` builds natively, which is what comma's own CI does. |
+| `release_tag` | blank | blank means `agnos-tici-boot-<run number>` |
+| `open_pr` | true | commit the manifest update on a branch and open a PR against the branch the run was dispatched from |
+
+The job clones the kernel shallow at `kernel_commit`, applies the patch, runs `./build_kernel.sh`
+unmodified, checks the tici device tree made it into `boot.img`, packages, publishes, and opens the
+PR. It takes the better part of an hour cold and rather less with a ccache hit.
+
+### Reproducing it by hand
+
+Any Linux box with Docker. macOS needs a case-sensitive APFS volume, which is why this is a
+workflow and not something you run locally by default.
+
+```bash
+git clone https://github.com/commaai/agnos-builder
+cd agnos-builder
+git checkout 8f7207a4f083ce3215f893a01b74613c507cc4bc
+git submodule update --init agnos-kernel-sdm845
+git -C agnos-kernel-sdm845 checkout c368754c26c7b9659de187addc6cccedc6cfb0a0
+git -C agnos-kernel-sdm845 apply /path/to/zoompilot/scripts/agnos/restore-comma_tici-dts.patch
+./build_kernel.sh                                  # produces output/boot.img
+```
+
+Then package it the way `agnos-builder/scripts/package_ota.py` would:
+
+```bash
+cd /path/to/zoompilot
+NAME=$(scripts/agnos/manifest_entry.py /path/to/agnos-builder/output/boot.img --xz-name)
+xz -9 -T1 -c /path/to/agnos-builder/output/boot.img > "$NAME"
+scripts/agnos/manifest_entry.py /path/to/agnos-builder/output/boot.img \
+  --url "https://github.com/zoompilot/zoompilot/releases/download/<tag>/$NAME" \
+  --verify-xz "$NAME" -o entry.json
+scripts/agnos/update_manifest.py openpilot/common/hardware/comma/tici_agnos.json entry.json
+```
+
+`boot.img` is not reproducible byte for byte between runs. `mkbootimg` output is deterministic, but
+the kernel records a build timestamp, so two builds of the same commit give different hashes. Every
+build therefore needs its own manifest entry; do not hand-edit a URL to point at a different build.
+
+## The manifest entry
+
+`openpilot/common/hardware/comma/agnos.py` is the flasher, and every field means something specific
+to it. Getting one wrong is how you brick a device, so:
+
+| field | value for `boot` | what reads it |
+|---|---|---|
+| `name` | `boot` | `get_partition_path()` builds `/dev/disk/by-partlabel/boot_a` or `_b` from it |
+| `url` | the release asset | streamed and lzma-decompressed by `StreamingDecompressor` |
+| `hash` | sha256 of the **decompressed stream** | checked after flashing against `downloader.sha256` |
+| `hash_raw` | sha256 of the bytes **written to the partition** | checked after flashing, and re-checked on every `verify_partition()` |
+| `size` | length in bytes of the raw image | the flash fails if the stream is not exactly this long; `verify_partition()` hashes exactly this many bytes off the partition |
+| `sparse` | `false` | picks `noop()` over `unsparsify()`, i.e. write the stream straight through |
+| `full_check` | `true` | verify by re-hashing the partition rather than by reading a hash string stored just past the image |
+| `has_ab` | `true` | append the `_a` / `_b` slot suffix to the partition path |
+| `ondevice_hash` | sha256 of the image zero padded to a 4096 byte sector | nothing in openpilot. It is provenance for comma's tooling; we emit it so the entry has the same shape as comma's. |
+
+`hash` and `hash_raw` are equal here and must be. They differ only for sparse images, where `hash`
+covers the sparse container and `hash_raw` covers the unpacked result. openpilot's own manifest test
+asserts `hash == hash_raw` for every non-sparse entry.
+
+`full_check: true` matters for what happens after a bad flash. With `full_check` false the updater
+writes the expected hash as ASCII into the partition just past the image and trusts it later; with
+it true, `verify_partition()` re-reads and re-hashes `size` bytes off the block device every time,
+so a partition that was corrupted after the fact is caught rather than trusted. `boot` is 45-ish MB,
+which is cheap enough to re-hash.
+
+`size` must be the raw image length, not the partition length. `verify_partition()` reads exactly
+`size` bytes, so whatever the previous image left beyond that is ignored.
+
+`manifest_entry.py` refuses an image over 64 MiB. That bound is inferred from the size of comma's
+own boot images, **not** read off a comma three's GPT. Confirm it against the real partition before
+trusting it:
+
+```bash
+# on a device
+sudo sgdisk -p /dev/disk/by-id/... | grep -i boot
+lsblk -b -o NAME,SIZE /dev/disk/by-partlabel/boot_a
+```
+
+While the entry is still `REPLACED_BY_BUILD`, `verify_partition()` returns `False` because `size`
+is not an `int`, so a half-filled manifest fails safe rather than flashing a placeholder.
+
+## Verifying a build
+
+The workflow already does the first three. Do the rest before you put it on a device.
+
+1. **The dtb was built.** `out/arch/arm64/boot/dts/qcom/comma_tici.dtb` exists.
+2. **The dtb reached the boot image.** `strings -a output/boot.img | grep -x 'comma tici'`. The
+   workflow fails if this misses, and warns if `comma tizi` or `comma mici` went missing, which
+   would mean the append list changed.
+3. **The published `.img.xz` round trips.** `manifest_entry.py --verify-xz` decompresses it through
+   the same single `LZMADecompressor` that `agnos.py` uses and checks the length and hash. This
+   catches the one packaging footgun that matters: `xz -T0` can emit concatenated streams, and
+   `agnos.py` stops at the first stream end, which would silently truncate the flash. The workflow
+   compresses single threaded for that reason. Compression level does not affect any manifest
+   field, since every hash is of the plain image.
+4. **Decompile the dtb and read it.** `dtc -I dtb -O dts out/.../comma_tici.dtb` and confirm
+   `model = "comma tici"` and that `qcom,msm-id` / `qcom,board-id` match what the deleted file had.
+5. **Compare against a known-good image.** Pull AGNOS 12.8's `boot` image, split the appended dtbs
+   out of both and diff the tici dtb. Differences should be confined to what changed in
+   `comma_common.dtsi` (one PCIe disable) and `sda845-v2.1.dtsi` between 12.8 and the pinned commit.
+   This is the strongest check available without hardware and it has not been done.
+6. **On the device**, after flashing and before swapping slots:
+   `openpilot/common/hardware/comma/agnos.py --verify openpilot/system/hardware/comma/tici_agnos.json`.
+
+The `Content-Type` of a GitHub release asset is not necessarily `application/x-xz`.
+`openpilot/common/hardware/comma/tests/test_agnos_updater.py` asserts that header, but only for
+`agnos.json`. If that test is ever extended to `tici_agnos.json` it may fail on our asset even
+though the asset is fine.
+
+## Flashing
+
+The safe path is the updater's: it marks the **inactive** slot unbootable, flashes it, verifies it,
+and only then calls `abctl --set_active`. The slot you are running from is never touched, so a bad
+image costs a failed boot rather than a device.
+
+To try an image without going through the updater, do the same thing by hand and keep the fallback
+slot intact:
+
+```bash
+# on the device
+abctl --boot_slot                       # which slot is live now
+sudo dd if=boot.img of=/dev/disk/by-partlabel/boot_b   # the OTHER one
+sudo abctl --set_active 1               # 1 for _b, 0 for _a
+sudo reboot
+```
+
+agnos-builder's own `load_kernel.sh` dds to **both** `boot_a` and `boot_b`. Do not use it here.
+That destroys the fallback slot, which is the only thing standing between a bad kernel and a QDL
+session.
+
+## Recovery
+
+Flashing a bad boot partition does not brick the device permanently, but it can leave it unable to
+boot at all, and the usual escape hatch is worse for a comma three than for other devices.
+
+- **Slot fallback.** If only one slot is bad the bootloader falls back to the other after its retry
+  count runs out. This is the reason for flashing the inactive slot only.
+- **QDL.** `xbl`, `xbl_config` and `abl` are never written by this workflow, so the bootloader and
+  its QDL/EDL entry survive whatever happens to `boot`. Recovery is
+  `agnos-builder/tools/qdl flash boot <known-good boot.img>`, which is what
+  `agnos-builder/flash_kernel.sh` does. Getting the device into QDL mode is documented at
+  <https://flash.comma.ai>.
+- **Keep a known-good image on the host before you flash.** This is the part that bites. Current
+  AGNOS releases, and therefore <https://flash.comma.ai>, contain no comma three device tree, so
+  reflashing to "factory" does **not** get a comma three booting again. The only boot images that
+  work are AGNOS 12.8's and ones built like this. Download 12.8's `boot` image, or keep the
+  previous working build, before you flash a new one.
+
+## Files
+
+| path | what |
+|---|---|
+| `.github/workflows/zoompilot-agnos-tici-boot.yaml` | the build, package, publish and PR |
+| `scripts/agnos/restore-comma_tici-dts.patch` | the deleted DTS and the one `Makefile` line |
+| `scripts/agnos/manifest_entry.py` | computes and verifies a manifest entry for a flat image |
+| `scripts/agnos/update_manifest.py` | swaps one entry into a manifest |
+| `openpilot/common/hardware/comma/tici_agnos.json` | the comma three's manifest |
+| `docs/comma-three-port.md` | the rest of the port |

--- a/scripts/agnos/manifest_entry.py
+++ b/scripts/agnos/manifest_entry.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of zoompilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+Build the AGNOS manifest entry for a non-sparse partition image, and verify that
+the .img.xz we publish decompresses back to exactly what the entry claims.
+
+The field semantics are those of commaai/agnos-builder scripts/package_ota.py,
+which is what produces comma's own agnos.json, and of the flasher that consumes
+them, openpilot/common/hardware/comma/agnos.py:
+
+  size          bytes written to the partition. agnos.py fails the flash if the
+                decompressed stream is not exactly this long.
+  hash          sha256 of the decompressed stream. For a non-sparse image that is
+                the image itself, so hash == hash_raw. openpilot's own manifest
+                test asserts that equality for every non-sparse entry.
+  hash_raw      sha256 of the bytes written to the partition. This is the one
+                that is re-read and compared on every boot when full_check is
+                true, and the one the .img.xz file name carries.
+  ondevice_hash sha256 of the image zero padded up to a 4096 byte sector. Nothing
+                in openpilot reads it; it is provenance for comma's own tooling.
+                Emitted anyway so our entry has the same shape as comma's.
+  sparse        false. boot is a flat Android boot image, not an Android sparse
+                image, so agnos.py streams it straight to the partition.
+  full_check    true. agnos.py re-hashes the first `size` bytes of the partition
+                on every check instead of trusting a hash string written past the
+                end of the image. boot is small enough to afford it.
+  has_ab        true. boot exists as boot_a and boot_b and the updater flashes
+                the inactive slot.
+
+Usage:
+  manifest_entry.py boot.img --url https://.../boot-<hash_raw>.img.xz
+  manifest_entry.py boot.img --xz-name          # just print the file name to publish
+  manifest_entry.py boot.img --verify-xz boot-<hash_raw>.img.xz
+"""
+
+import argparse
+import hashlib
+import json
+import lzma
+import struct
+import sys
+from pathlib import Path
+
+SECTOR_SIZE = 4096
+SPARSE_MAGIC = 0xED26FF3A
+
+# The tici boot partition. Anything larger cannot be flashed. Derived from
+# comma's own boot.img sizes, not read off a device, so treat it as a sanity
+# bound rather than the truth. See docs/agnos-tici-boot.md.
+MAX_BOOT_SIZE = 64 * 1024 * 1024
+
+
+def build_entry(path: Path, name: str, url: str) -> dict:
+  data = path.read_bytes()
+  size = len(data)
+
+  if size >= 4 and struct.unpack("<I", data[:4])[0] == SPARSE_MAGIC:
+    raise SystemExit(f"{path} is an Android sparse image; this script only handles flat images")
+
+  digest = hashlib.sha256(data).hexdigest()
+
+  padded = hashlib.sha256(data)
+  padded.update(b"\x00" * ((SECTOR_SIZE - (size % SECTOR_SIZE)) % SECTOR_SIZE))
+
+  return {
+    "name": name,
+    "url": url,
+    "hash": digest,
+    "hash_raw": digest,
+    "size": size,
+    "sparse": False,
+    "full_check": True,
+    "has_ab": True,
+    "ondevice_hash": padded.hexdigest(),
+  }
+
+
+def verify_xz(xz_path: Path, entry: dict) -> None:
+  """Decompress the way agnos.py does and check the entry against the result.
+
+  agnos.py uses a single LZMADecompressor and stops at the first stream EOF, so a
+  .img.xz built as several concatenated xz streams would silently truncate on
+  device. Streaming it back through the same decompressor catches that here.
+  """
+  decompressor = lzma.LZMADecompressor(format=lzma.FORMAT_AUTO)
+  sha256 = hashlib.sha256()
+  total = 0
+
+  with open(xz_path, "rb") as f:
+    while chunk := f.read(1024 * 1024):
+      out = decompressor.decompress(chunk)
+      sha256.update(out)
+      total += len(out)
+      if decompressor.eof:
+        break
+    trailing = len(decompressor.unused_data) + len(f.read())
+
+  if not decompressor.eof:
+    raise SystemExit(f"{xz_path}: decompressor never hit end of stream")
+  if trailing:
+    raise SystemExit(f"{xz_path}: trailing data after the first xz stream; rebuild single threaded so agnos.py reads the whole image")
+  if total != entry["size"]:
+    raise SystemExit(f"{xz_path}: decompressed to {total} bytes, entry says {entry['size']}")
+  if sha256.hexdigest() != entry["hash"]:
+    raise SystemExit(f"{xz_path}: decompressed hash {sha256.hexdigest()}, entry says {entry['hash']}")
+
+  print(f"verified {xz_path}: {total} bytes, sha256 {sha256.hexdigest()}", file=sys.stderr)
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+  parser.add_argument("image", type=Path, help="the partition image, e.g. output/boot.img")
+  parser.add_argument("--name", default="boot", help="partition name")
+  parser.add_argument("--url", default="", help="URL the .img.xz will be published at")
+  parser.add_argument("--xz-name", action="store_true", help="print the file name to publish and exit")
+  parser.add_argument("--verify-xz", type=Path, help="check this .img.xz decompresses to the image")
+  parser.add_argument("--max-size", type=int, default=MAX_BOOT_SIZE, help="refuse an image larger than this")
+  parser.add_argument("-o", "--output", type=Path, help="write the entry JSON here as well as to stdout")
+  args = parser.parse_args()
+
+  entry = build_entry(args.image, args.name, args.url)
+
+  if args.max_size and entry["size"] > args.max_size:
+    raise SystemExit(f"{args.image} is {entry['size']} bytes, over the {args.max_size} byte partition bound")
+
+  if args.xz_name:
+    print(f"{args.name}-{entry['hash_raw']}.img.xz")
+    return
+
+  if args.verify_xz is not None:
+    verify_xz(args.verify_xz, entry)
+
+  out = json.dumps(entry, indent=2)
+  print(out)
+  if args.output:
+    args.output.write_text(out + "\n")
+
+
+if __name__ == "__main__":
+  main()

--- a/scripts/agnos/restore-comma_tici-dts.patch
+++ b/scripts/agnos/restore-comma_tici-dts.patch
@@ -1,0 +1,186 @@
+Restore comma_tici.dts to the AGNOS kernel.
+
+comma deleted arch/arm64/boot/dts/qcom/comma_tici.dts and its Makefile line in
+agnos-kernel-sdm845 b90695f101ba (2025-08-26), so every AGNOS from 13 on ships a
+boot image with no device tree for the comma three. This patch is that commit
+reverted onto agnos-kernel-sdm845 c368754c26c7b9659de187addc6cccedc6cfb0a0, the
+kernel agnos-builder pins.
+
+The .dts is byte-identical to the deleted file. Its includes, sda845-v2.1.dtsi
+and comma_common.dtsi, are both still present. tici_defconfig sets
+CONFIG_BUILD_ARM64_APPENDED_DTB_IMAGE_NAMES="", so arch/arm64/boot/Makefile
+appends every built dtb to Image-dtb; the Makefile line is all that is needed to
+get comma_tici.dtb into the boot image alongside tizi and mici.
+
+Apply from the root of an agnos-kernel-sdm845 checkout:
+
+  git apply /path/to/restore-comma_tici-dts.patch
+
+The Makefile hunk has three lines of context around the other comma dtb entries.
+If a newer kernel adds or removes a board there, refresh this patch rather than
+forcing it through with fuzz.
+
+diff --git a/arch/arm64/boot/dts/qcom/Makefile b/arch/arm64/boot/dts/qcom/Makefile
+index 1d2302a..dc5df64 100644
+--- a/arch/arm64/boot/dts/qcom/Makefile
++++ b/arch/arm64/boot/dts/qcom/Makefile
+@@ -2,6 +2,7 @@
+ #dtb-$(CONFIG_ARCH_QCOM)	+= msm8996-mtp.dtb
+ #dtb-$(CONFIG_ARCH_QCOM)	+= apq8096-db820c.dtb
+ 
++dtb-$(CONFIG_ARCH_SDM845) += comma_tici.dtb
+ dtb-$(CONFIG_ARCH_SDM845) += comma_tizi.dtb
+ dtb-$(CONFIG_ARCH_SDM845) += comma_mici.dtb
+ dtb-$(CONFIG_ARCH_SDM845) += comma_ultimate_provisioning.dtb
+diff --git a/arch/arm64/boot/dts/qcom/comma_tici.dts b/arch/arm64/boot/dts/qcom/comma_tici.dts
+new file mode 100644
+index 0000000..c44b1ea
+--- /dev/null
++++ b/arch/arm64/boot/dts/qcom/comma_tici.dts
+@@ -0,0 +1,146 @@
++/* Copyright (c) 2017, The Linux Foundation. All rights reserved.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License version 2 and
++ * only version 2 as published by the Free Software Foundation.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ */
++
++
++/dts-v1/;
++
++#include <dt-bindings/clock/qcom,gcc-sdm845.h>
++#include <dt-bindings/clock/qcom,camcc-sdm845.h>
++#include <dt-bindings/clock/qcom,dispcc-sdm845.h>
++#include <dt-bindings/clock/qcom,rpmh.h>
++#include <dt-bindings/interrupt-controller/arm-gic.h>
++
++#include "sda845-v2.1.dtsi"
++
++#include "comma_common.dtsi"
++
++/* light(RPR-0521RS) and touch panel I2C, /dev/i2c-2 */
++&qupv3_se5_i2c {
++  status = "ok";
++  qcom,clk-freq-out = <100000>;
++
++  rpr0521@38 {
++    compatible = "rpr0521";
++    reg = <0x38>;
++  };
++
++  samsung-ts@17 {
++    compatible = "samsung_i2c_touchpanel";
++    reg = <0x17>;
++    interrupt-parent = <&tlmm>;
++		interrupts = <125 0x2002>;
++    interrupt-gpios = <&tlmm 125 0x2002>;
++    reset-gpios = <&tlmm 104 0>;
++    ta-gpios = <&tlmm 128 0>;
++    vdd-supply = <&tp3v3>;
++  };
++};
++
++/* GPS UART */
++&qupv3_gps_uart {
++  status = "ok";
++};
++
++&vendor {
++  main5v: main5v {
++    status = "ok";
++
++    compatible = "regulator-fixed";
++    regulator-name = "main5v";
++    regulator-min-microvolt = <5000000>;
++    regulator-max-microvolt = <5000000>;
++
++    gpio = <&tlmm 25 0>;
++    enable-active-high;
++    regulator-always-on;
++  };
++
++	lcd3v3: lcd3v3 {
++    status = "ok";
++
++    compatible = "regulator-fixed";
++    regulator-name = "lcd3v3";
++    regulator-min-microvolt = <3300000>;
++    regulator-max-microvolt = <3300000>;
++
++    gpio = <&pm8998_gpios 13 0>;
++    regulator-boot-on;
++    regulator-always-on;
++  };
++
++  tp3v3: tp3v3 {
++   status = "ok";
++
++   compatible = "regulator-fixed";
++   regulator-name = "tp3v3";
++   regulator-min-microvolt = <3300000>;
++   regulator-max-microvolt = <3300000>;
++
++   gpio = <&pm8998_gpios 10 0>;
++   regulator-boot-on;
++   regulator-always-on;
++  };
++
++  ssd3v3: ssd3v3 {
++    status = "ok";
++
++    compatible = "regulator-fixed";
++    regulator-name = "ssd3v3";
++    regulator-min-microvolt = <3300000>;
++    regulator-max-microvolt = <3300000>;
++
++    gpio = <&tlmm 41 0>;
++    enable-active-high;
++    regulator-always-on;
++  };
++};
++
++&soc {
++	dsi_ss_ea8074_fhd_cmd_display: qcom,dsi-display@0 {
++    compatible = "qcom,dsi-display";
++    label = "dsi_ss_ea8074_fhd_cmd_display";
++    qcom,display-type = "primary";
++    qcom,dsi-display-active;
++
++    qcom,dsi-ctrl = <&mdss_dsi0>;
++    qcom,dsi-phy = <&mdss_dsi_phy0>;
++    clocks = <&mdss_dsi0_pll BYTECLK_MUX_0_CLK>, <&mdss_dsi0_pll PCLK_MUX_0_CLK>;
++		clock-names = "src_byte_clk", "src_pixel_clk";
++
++    pinctrl-names = "panel_active", "panel_suspend";
++    //pinctrl-0 = <&sde_dsi_active &sde_te_active &lcd_3v3_en_n_active &tp_3v3_en_n_active>;
++    //pinctrl-1 = <&sde_dsi_suspend &sde_te_suspend &lcd_3v3_en_n_suspend &tp_3v3_en_n_suspend>;
++    pinctrl-0 = <&sde_dsi_active &sde_te_active>;
++    pinctrl-1 = <&sde_dsi_suspend &sde_te_suspend>;
++
++    qcom,dsi-panel = <&dsi_ss_fhd_ea8074_cmd>;
++    vddio-supply = <&pm8998_l14>;
++    vddcore-supply = <&lcd3v3>;
++
++    /*vci-supply = <&disp_vci_vreg>;*/
++  };
++};
++
++&mdss_dsi0 {
++	status = "ok";
++  qcom,dsi-pref-prim-pan = <&dsi_ss_fhd_ea8074_cmd>;
++};
++
++
++
++/* Board definition */
++/ {
++	model = "comma tici";
++	compatible = "qcom,sda845-mtp", "qcom,sda845", "qcom,mtp";
++	qcom,msm-id = <341 0x20001>, <321 0x20001>, <321 0x20000>;
++	qcom,board-id = <0x8 0>, <0x20 0>; // Support both old and new XBL
++};

--- a/scripts/agnos/update_manifest.py
+++ b/scripts/agnos/update_manifest.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of zoompilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+
+Replace one partition entry in an AGNOS manifest with a freshly built one.
+
+Only the named entry is touched, so the comma three keeps comma's official xbl,
+xbl_config, abl, aop, devcfg and system images and takes only boot from us.
+
+Usage:
+  update_manifest.py openpilot/common/hardware/comma/tici_agnos.json entry.json \\
+      --comment "built by <run url> from kernel <sha>"
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+REQUIRED = ("name", "url", "hash", "hash_raw", "size", "sparse", "full_check", "has_ab")
+
+
+def main() -> None:
+  parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+  parser.add_argument("manifest", type=Path)
+  parser.add_argument("entry", type=Path, help="JSON object produced by manifest_entry.py")
+  parser.add_argument("--comment", default="", help="provenance string stored as _comment")
+  args = parser.parse_args()
+
+  entry = json.loads(args.entry.read_text())
+  missing = [k for k in REQUIRED if k not in entry]
+  if missing:
+    raise SystemExit(f"entry is missing {missing}")
+  if not entry["sparse"] and entry["hash"] != entry["hash_raw"]:
+    raise SystemExit("non-sparse entry must have hash == hash_raw")
+  if not entry["url"].startswith("https://"):
+    raise SystemExit(f"refusing a non-https url: {entry['url']}")
+
+  if args.comment:
+    entry["_comment"] = args.comment
+
+  manifest = json.loads(args.manifest.read_text())
+  matches = [i for i, p in enumerate(manifest) if p["name"] == entry["name"]]
+  if len(matches) != 1:
+    raise SystemExit(f"expected exactly one '{entry['name']}' entry in {args.manifest}, found {len(matches)}")
+
+  manifest[matches[0]] = entry
+  args.manifest.write_text(json.dumps(manifest, indent=2) + "\n")
+  print(f"updated {entry['name']} in {args.manifest}")
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
The first run failed at the guard step. A bare `git init` in the submodule path leaves it uninitialized as far as the parent repo is concerned (`git submodule status --cached` reports a leading `-`), so `build_kernel.sh` would have re-cloned the kernel and silently discarded the DTS patch, producing an image that looked fine and had no comma three device tree.

Initializing through `git submodule update --init --depth 1` and then checking out the pinned commit fixes it. The guard did its job.

Verified end to end on run 34095452478: kernel built, `comma_tici.dtb` present, and the published image decompresses to the manifest hash and carries the `comma tici` device tree.