### PR TITLE
agnos: init the kernel through git submodule

### DIFF
--- a/.github/workflows/zoompilot-agnos-tici-boot.yaml
+++ b/.github/workflows/zoompilot-agnos-tici-boot.yaml
@@ -80,13 +80,12 @@ jobs:
         working-directory: agnos-builder
         run: |
           set -e
-          rm -rf agnos-kernel-sdm845
-          mkdir agnos-kernel-sdm845
+          git submodule update --init --depth 1 agnos-kernel-sdm845
           cd agnos-kernel-sdm845
-          git init -q .
-          git remote add origin https://github.com/commaai/agnos-kernel-sdm845.git
-          git fetch --depth 1 origin ${{ inputs.kernel_commit }}
-          git checkout -q --detach FETCH_HEAD
+          if [ "$(git rev-parse HEAD)" != "${{ inputs.kernel_commit }}" ]; then
+            git fetch --depth 1 origin ${{ inputs.kernel_commit }}
+            git checkout -q --detach FETCH_HEAD
+          fi
           git log -1 --format='kernel %H %ci %s'
 
       # build_kernel.sh re-clones the submodule if it looks uninitialized. It does not


### PR DESCRIPTION
The first build failed at the guard step. A bare `git init` in the submodule path leaves it uninitialized as far as the parent repo is concerned, so `build_kernel.sh` would have re-cloned the kernel and silently discarded the DTS patch, producing an image that looked fine and contained no comma three device tree. The guard did its job.

Verified end to end on run 34095452478 with this fix: kernel built, `comma_tici.dtb` present in the image, and the published asset decompresses to the manifest hash and carries the `comma tici` device tree.