### PR TITLE
agnos: harden the tici boot tooling

### DIFF
--- a/.github/workflows/zoompilot-agnos-tici-boot.yaml
+++ b/.github/workflows/zoompilot-agnos-tici-boot.yaml
@@ -87,6 +87,8 @@ jobs:
             git checkout -q --detach FETCH_HEAD
           fi
           git log -1 --format='kernel %H %ci %s'
+          # the inputs accept a branch name, so record what was actually built
+          echo "KERNEL_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
 
       # build_kernel.sh re-clones the submodule if it looks uninitialized. It does not
       # here, because the directory now has its own .git, but a silent re-clone would
@@ -177,7 +179,7 @@ jobs:
           {
             echo '## tici boot image'
             echo
-            echo "- kernel \`${{ inputs.kernel_commit }}\` with \`comma_tici.dts\` restored"
+            echo "- kernel \`$KERNEL_SHA\` with \`comma_tici.dts\` restored (requested \`${{ inputs.kernel_commit }}\`)"
             echo "- agnos-builder \`${{ inputs.agnos_builder_commit }}\`"
             echo "- built on \`${{ inputs.runner }}\`"
             echo
@@ -214,7 +216,7 @@ jobs:
           This is not comma's official boot image and cannot be reproduced bit for bit against one.
           Read `docs/agnos-tici-boot.md` before flashing it.
           EOF
-          sed -i "s/KERNEL_COMMIT/${{ inputs.kernel_commit }}/; s/BUILDER_COMMIT/${{ inputs.agnos_builder_commit }}/" "$RUNNER_TEMP/notes.md"
+          sed -i "s/KERNEL_COMMIT/$KERNEL_SHA/; s/BUILDER_COMMIT/${{ inputs.agnos_builder_commit }}/" "$RUNNER_TEMP/notes.md"
           if ! gh release view "$TAG" --repo "${{ github.repository }}" >/dev/null 2>&1; then
             gh release create "$TAG" --repo "${{ github.repository }}" \
               --title "AGNOS tici boot $TAG" \
@@ -236,9 +238,9 @@ jobs:
           git checkout -b "$BRANCH"
           python3 scripts/agnos/update_manifest.py \
             openpilot/common/hardware/comma/tici_agnos.json "$GITHUB_WORKSPACE/entry.json" \
-            --comment "kernel ${{ inputs.kernel_commit }} with comma_tici.dts restored, agnos-builder ${{ inputs.agnos_builder_commit }}, built by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            --comment "kernel $KERNEL_SHA with comma_tici.dts restored, agnos-builder ${{ inputs.agnos_builder_commit }}, built by ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           git add openpilot/common/hardware/comma/tici_agnos.json
-          SHORT=$(echo "${{ inputs.kernel_commit }}" | cut -c1-9)
+          SHORT=$(echo "$KERNEL_SHA" | cut -c1-9)
           git commit -m "agnos: tici boot image from kernel $SHORT"
           git push origin "$BRANCH"
           cat > "$RUNNER_TEMP/pr.md" <<'EOF'
@@ -253,7 +255,7 @@ jobs:
           sed -i \
             -e "s/RUN_ID/${{ github.run_id }}/" \
             -e "s#RUN_URL#${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#" \
-            -e "s/KERNEL_COMMIT/${{ inputs.kernel_commit }}/" \
+            -e "s/KERNEL_COMMIT/$KERNEL_SHA/" \
             -e "s/BUILDER_COMMIT/${{ inputs.agnos_builder_commit }}/" \
             -e "s/ASSET_NAME/${{ steps.package.outputs.asset }}/" \
             "$RUNNER_TEMP/pr.md"

--- a/docs/agnos-tici-boot.md
+++ b/docs/agnos-tici-boot.md
@@ -186,16 +186,46 @@ To try an image without going through the updater, do the same thing by hand and
 slot intact:
 
 ```bash
-# on the device
-abctl --boot_slot                       # which slot is live now
-sudo dd if=boot.img of=/dev/disk/by-partlabel/boot_b   # the OTHER one
-sudo abctl --set_active 1               # 1 for _b, 0 for _a
+# on the device. Derive the inactive slot, never hardcode it: writing the slot you
+# are running from destroys the fallback this whole procedure depends on.
+live=$(abctl --boot_slot | tr -d '[:space:]')   # a or b
+case "$live" in
+  a) target=b; idx=1 ;;
+  b) target=a; idx=0 ;;
+  *) echo "could not read the live slot, stop here"; exit 1 ;;
+esac
+echo "live slot $live, writing boot_$target"
+
+sudo dd if=boot.img of=/dev/disk/by-partlabel/boot_$target
+sudo abctl --set_active $idx
 sudo reboot
 ```
+
+This is what `agnos.py` does: `get_target_slot_number()` picks the inactive slot, and the updater
+verifies the write before it ever calls `abctl --set_active`.
 
 agnos-builder's own `load_kernel.sh` dds to **both** `boot_a` and `boot_b`. Do not use it here.
 That destroys the fallback slot, which is the only thing standing between a bad kernel and a QDL
 session.
+
+## Which partitions come from where
+
+This is the part that is easy to get wrong, and getting it wrong looks like
+`Unsupported firmware detected` on a black screen at boot, before openpilot runs at all.
+
+| partition | source | why |
+|---|---|---|
+| `xbl`, `xbl_config`, `aop`, `devcfg` | comma, current AGNOS | byte identical between 18.4 and 19.7, not device specific |
+| `abl` | **comma, AGNOS 12.8** | the last bootloader comma shipped for the comma three. A newer `abl` rejects the board |
+| `boot` | **ours** | comma's kernel has no `comma_tici.dtb` from AGNOS 13 on |
+| `system` | comma, current AGNOS | the rootfs, shared across devices |
+
+Both field validated comma three forks, sunnypilot's `sync-20251218-tici` and opgm's `master-c3`,
+independently pin 12.8's `abl` alongside a much newer everything else. That combination looked like
+an unexplained hybrid at first and it is not: `abl` is the one bootloader partition that is device
+specific, and it is the piece that decides whether the board is allowed to boot at all.
+
+If you ever bump the AGNOS version here, carry `abl` forward unchanged.
 
 ## Recovery
 
@@ -204,8 +234,13 @@ boot at all, and the usual escape hatch is worse for a comma three than for othe
 
 - **Slot fallback.** If only one slot is bad the bootloader falls back to the other after its retry
   count runs out. This is the reason for flashing the inactive slot only.
-- **QDL.** `xbl`, `xbl_config` and `abl` are never written by this workflow, so the bootloader and
-  its QDL/EDL entry survive whatever happens to `boot`. Recovery is
+- **QDL always survives, but not for the reason you might assume.** This workflow only ever
+  produces `boot`, however `tici_agnos.json` is a whole manifest: taking an AGNOS update through
+  the updater also writes comma's `xbl`, `xbl_config`, `abl`, `aop` and `devcfg` to the target
+  slot, exactly as it would on a 3X. A comma three therefore does run a bootloader newer than any
+  comma shipped for it, which is the same arrangement the third party 18.4 images already in the
+  field use. What makes QDL safe is that EDL lives in the SoC boot ROM, not in a partition, so it
+  is reachable however badly `boot` or even `xbl` is written. Recovery is
   `agnos-builder/tools/qdl flash boot <known-good boot.img>`, which is what
   `agnos-builder/flash_kernel.sh` does. Getting the device into QDL mode is documented at
   <https://flash.comma.ai>.
@@ -214,6 +249,27 @@ boot at all, and the usual escape hatch is worse for a comma three than for othe
   reflashing to "factory" does **not** get a comma three booting again. The only boot images that
   work are AGNOS 12.8's and ones built like this. Download 12.8's `boot` image, or keep the
   previous working build, before you flash a new one.
+
+## If the device shows "Unsupported firmware detected"
+
+A black screen reading `Unsupported firmware detected` with a link to
+`commaai/hardware/tree/master/comma_three` is the bootloader refusing the board. It happens before
+openpilot runs, so nothing in openpilot can fix it. The cause was a manifest carrying a newer `abl`
+than 12.8; see the table above.
+
+The device is not bricked. The bootloader is running, which means `xbl` and the boot ROM are fine.
+
+1. **Try the other slot first.** The updater flashes the inactive slot and switches to it, so the
+   slot you were on before the update is still intact. Let it fail its retry count and the
+   bootloader should fall back on its own. From a working shell, `abctl --set_active` back to the
+   previous slot.
+2. **Otherwise reflash AGNOS 12.8 over QDL.** 12.8 is the last release comma built for the comma
+   three and it is still on the CDN. Get the device into QDL mode as described at
+   <https://flash.comma.ai>, then flash 12.8's images with `agnos-builder/tools/qdl`. Do **not** use
+   flash.comma.ai's own bundle: it serves current AGNOS, which has neither a `comma_tici` device
+   tree nor a compatible `abl`, so it puts the device back into exactly this state.
+3. Then install `develop-tici` again. With 12.8's `abl` pinned, the update no longer replaces the
+   bootloader with one that rejects the board.
 
 ## Files
 

--- a/scripts/agnos/manifest_entry.py
+++ b/scripts/agnos/manifest_entry.py
@@ -47,10 +47,10 @@ from pathlib import Path
 
 SECTOR_SIZE = 4096
 SPARSE_MAGIC = 0xED26FF3A
+BOOT_MAGIC = b"ANDROID!"
 
-# The tici boot partition. Anything larger cannot be flashed. Derived from
-# comma's own boot.img sizes, not read off a device, so treat it as a sanity
-# bound rather than the truth. See docs/agnos-tici-boot.md.
+# boot_a and boot_b are 67108864 bytes each, read out of comma's gpt_main_4.
+# Anything larger cannot be flashed.
 MAX_BOOT_SIZE = 64 * 1024 * 1024
 
 
@@ -60,6 +60,14 @@ def build_entry(path: Path, name: str, url: str) -> dict:
 
   if size >= 4 and struct.unpack("<I", data[:4])[0] == SPARSE_MAGIC:
     raise SystemExit(f"{path} is an Android sparse image; this script only handles flat images")
+
+  # Every other defect here (wrong hash, wrong size, wrong url) aborts the flash and
+  # leaves the device on its current slot. An internally consistent image the
+  # bootloader refuses is the one input that survives verification and still reaches
+  # abctl --set_active, so refuse anything that is not a signed Android boot image.
+  # build_kernel.sh leaves the unsigned boot.img.nonsecure next to the real one.
+  if data[:8] != BOOT_MAGIC:
+    raise SystemExit(f"{path} is not an Android boot image (no ANDROID! magic); refusing to publish it")
 
   digest = hashlib.sha256(data).hexdigest()
 

--- a/scripts/agnos/update_manifest.py
+++ b/scripts/agnos/update_manifest.py
@@ -33,10 +33,25 @@ def main() -> None:
   missing = [k for k in REQUIRED if k not in entry]
   if missing:
     raise SystemExit(f"entry is missing {missing}")
+  # agnos.py reads size as an int and hashes exactly that many bytes off the block
+  # device. A string size leaves a stub in the inactive boot partition and breaks
+  # updates permanently, so type check before this can reach a device.
+  if not isinstance(entry["size"], int) or entry["size"] <= 0:
+    raise SystemExit(f"size must be a positive int, got {entry['size']!r}")
+  for k in ("hash", "hash_raw"):
+    v = entry[k]
+    if not isinstance(v, str) or len(v) != 64 or any(c not in "0123456789abcdef" for c in v):
+      raise SystemExit(f"{k} must be a 64 character lowercase sha256, got {v!r}")
+  if entry["sparse"] is not False:
+    raise SystemExit("this script only writes flat images, sparse must be false")
   if not entry["sparse"] and entry["hash"] != entry["hash_raw"]:
     raise SystemExit("non-sparse entry must have hash == hash_raw")
   if not entry["url"].startswith("https://"):
     raise SystemExit(f"refusing a non-https url: {entry['url']}")
+  # the asset is named after its own hash, so a mismatch means the url and the
+  # hashes came from different builds
+  if entry["hash_raw"] not in entry["url"]:
+    raise SystemExit("url does not contain hash_raw; url and hashes are from different builds")
 
   if args.comment:
     entry["_comment"] = args.comment


### PR DESCRIPTION
The AGNOS boot workflow is registered on `develop`, so a dispatch uses the copies there, not the ones on `develop-tici`. These drifted apart while the comma three port was being debugged; this brings `develop` in step.

Substance, all of it found by review rather than by running it:

- `manifest_entry.py` refuses an image without the `ANDROID!` magic. `build_kernel.sh` leaves an unsigned `boot.img.nonsecure` beside the real one, and an internally consistent image the bootloader refuses is the *only* bad input that survives verification and still reaches `abctl --set_active`. Every other defect aborts the flash harmlessly.
- `update_manifest.py` type checks `size` and the hashes and rejects a url not containing `hash_raw`. A string `size` would leave a stub in the inactive boot partition and break updates permanently.
- The workflow records the *resolved* kernel sha, since the input accepts a branch name, and inits the kernel through `git submodule` so `build_kernel.sh` cannot re-clone over the DTS patch. That re-clone was a real failure on the first run.
- The docs flash steps hardcoded `boot_b` while telling you to write "the OTHER one", which on a device running `_b` overwrites the live slot and destroys the fallback. They derive the slot now. The recovery notes also claimed `xbl`/`abl` are never written, true of the workflow and false of the manifest.

No functional change to what gets built.