### PR TITLE
agnos: gzip the tici boot image so it fits the boot partition

### DIFF
--- a/.github/workflows/zoompilot-agnos-tici-boot.yaml
+++ b/.github/workflows/zoompilot-agnos-tici-boot.yaml
@@ -165,18 +165,20 @@ jobs:
       # broken: comma's uncompressed 19.7 image is exactly 46897152 bytes, 100% of the
       # partition, so appending a fourth device tree put us 372736 bytes over.
       #
-      # The limit checked here is the smaller, older one. comma grew the boot partition
-      # when it stopped compressing the kernel, and all-partitions.json only describes
-      # what a device gets from a current flash.comma.ai restore. A comma three that was
-      # last written by AGNOS 12.8 still has an 18515968 byte boot partition, and we
-      # would rather not require a restore.
+      # The limit that matters is the smaller, older one. comma grew the boot partition
+      # when it stopped compressing the kernel, and the all-partitions.json in this repo
+      # describes a comma four. flash.comma.ai reads its table for a comma three from
+      # commaai/openpilot branch release-tici, which is frozen at v0.10.0 and still
+      # flashes AGNOS 12.8, so a restored comma three has an 18515968 byte boot
+      # partition. Every other partition in the manifest fits both tables.
       - name: Confirm the image fits the boot partition
         run: |
           set -e
           size=$(stat -c %s agnos-builder/output/boot.img)
           current=$(python3 -c "import json; print([p['size'] for p in json.load(open('zoompilot/openpilot/common/hardware/comma/all-partitions.json')) if p['name'] == 'boot'][0])")
+          # commaai/openpilot release-tici system/hardware/tici/all-partitions.json
           legacy=18515968
-          echo "boot.img $size; boot partition is $current after a current restore, $legacy on an AGNOS 12.8 era device"
+          echo "boot.img $size; boot partition is $legacy on a comma three, $current on a comma four"
           for limit in "$legacy" "$current"; do
             if [ "$size" -gt "$limit" ]; then
               echo "::error::boot.img is $((size - limit)) bytes larger than a $limit byte boot partition; agnos.py could not write it"

--- a/.github/workflows/zoompilot-agnos-tici-boot.yaml
+++ b/.github/workflows/zoompilot-agnos-tici-boot.yaml
@@ -115,6 +115,14 @@ jobs:
           grep -q 'CONFIG_BUILD_ARM64_APPENDED_DTB_IMAGE_NAMES=""' arch/arm64/configs/tici_defconfig \
             || { echo "::error::tici_defconfig now names the appended dtbs; comma_tici.dtb must be added to that list"; exit 1; }
 
+      # comma's tici_defconfig builds an uncompressed kernel, and at 19.7 that image
+      # is exactly the size of the boot partition. A fourth device tree does not fit.
+      - name: Build the kernel image gzip compressed
+        run: |
+          zoompilot/scripts/agnos/gzip_kernel_image.sh \
+            agnos-builder/agnos-kernel-sdm845 \
+            agnos-builder/build_kernel.sh
+
       - name: Restore ccache
         uses: actions/cache@v4
         with:
@@ -131,9 +139,9 @@ jobs:
           CCACHE_MAXSIZE: 5G
         run: ./build_kernel.sh
 
-      # Image-dtb is the uncompressed kernel with every built dtb concatenated onto it,
+      # Image.gz-dtb is the gzipped kernel with every built dtb concatenated onto it,
       # and boot.img is that plus the mkbootimg header and comma's LE signature. The
-      # bootloader picks a dtb by qcom,msm-id and board-id, so all three comma boards
+      # bootloader picks a dtb by qcom,msm-id and board-id, so all four comma boards
       # ride in one image and the comma three simply had no entry to pick.
       - name: Confirm the tici device tree is in the image
         working-directory: agnos-builder
@@ -151,6 +159,31 @@ jobs:
             fi
           done
           ls -l output/boot.img
+
+      # agnos.py writes the decompressed image straight at the block device, so an
+      # image larger than the partition cannot be flashed at all. This is what shipped
+      # broken: comma's uncompressed 19.7 image is exactly 46897152 bytes, 100% of the
+      # partition, so appending a fourth device tree put us 372736 bytes over.
+      #
+      # The limit checked here is the smaller, older one. comma grew the boot partition
+      # when it stopped compressing the kernel, and all-partitions.json only describes
+      # what a device gets from a current flash.comma.ai restore. A comma three that was
+      # last written by AGNOS 12.8 still has an 18515968 byte boot partition, and we
+      # would rather not require a restore.
+      - name: Confirm the image fits the boot partition
+        run: |
+          set -e
+          size=$(stat -c %s agnos-builder/output/boot.img)
+          current=$(python3 -c "import json; print([p['size'] for p in json.load(open('zoompilot/openpilot/common/hardware/comma/all-partitions.json')) if p['name'] == 'boot'][0])")
+          legacy=18515968
+          echo "boot.img $size; boot partition is $current after a current restore, $legacy on an AGNOS 12.8 era device"
+          for limit in "$legacy" "$current"; do
+            if [ "$size" -gt "$limit" ]; then
+              echo "::error::boot.img is $((size - limit)) bytes larger than a $limit byte boot partition; agnos.py could not write it"
+              exit 1
+            fi
+          done
+          echo "fits with $((legacy - size)) bytes to spare on the tighter layout"
 
       - name: Package and hash
         id: package

--- a/docs/agnos-tici-boot.md
+++ b/docs/agnos-tici-boot.md
@@ -4,8 +4,10 @@
 cannot take from comma, publishes it as a release asset, and fills in the `boot` entry of
 `openpilot/common/hardware/comma/tici_agnos.json`.
 
-**Nothing in this document has been run on a comma three.** The image has never been built, never
-been flashed and never been booted. Read [Recovery](#recovery) before you flash anything.
+**The first image built from this workflow could not be flashed at all.** It was packaged
+uncompressed and came out larger than the boot partition, which is what left a tester sitting on
+the bootloader splash. The current image is gzipped and fits. See [Sizing](#sizing). Nothing here
+has yet booted a comma three; read [Recovery](#recovery) before you flash anything.
 
 ## Why
 
@@ -32,8 +34,10 @@ way `agnos-builder/build_kernel.sh` does it:
 
 - cross compiled with `DEFCONFIG=tici_defconfig` inside comma's `Dockerfile.builder` container
   (Ubuntu 20.04, python2, the Linaro `aarch64-linux-gnu` toolchain from `tools/`)
-- `Image-dtb` is the uncompressed `Image` with `comma_tici.dtb`, `comma_tizi.dtb`,
-  `comma_mici.dtb` and `comma_ultimate_provisioning.dtb` concatenated onto it
+- `Image.gz-dtb` is the gzipped `Image` with `comma_tici.dtb`, `comma_tizi.dtb`,
+  `comma_mici.dtb` and `comma_ultimate_provisioning.dtb` concatenated onto it. comma's current
+  `tici_defconfig` asks for the uncompressed `Image-dtb`;
+  `scripts/agnos/gzip_kernel_image.sh` flips it back, for the reasons under [Sizing](#sizing)
 - wrapped by `tools/mkbootimg` with comma's cmdline, 4096 byte pages, base `0x80000000`
 - signed with `vble-qti.key`, which is committed in the clear in agnos-builder, and the padded
   signature appended
@@ -56,6 +60,46 @@ against a specific `vermagic`), so the pairing is expected to work. Expected, no
 Both pins are workflow inputs. Raising `kernel_commit` is the intended way to track comma; the
 patch's `Makefile` hunk carries three lines of context and will need refreshing if a kernel bump
 adds or removes a board there.
+
+## Sizing
+
+The boot partition has no slack in it, and a comma three's is the small one.
+
+| image | bytes |
+|---|---|
+| AGNOS 12.8, gzip, 4 dtbs | 18515968 |
+| FrogPilot's rebuilt 18.4, gzip, 4 dtbs | 18130944 |
+| AGNOS 19.7, uncompressed, 3 dtbs | 46897152 |
+| ours as first published, uncompressed, 4 dtbs | 47269888 |
+| ours, gzip, 4 dtbs | 17864704 |
+
+| boot partition | bytes | who has it |
+|---|---|---|
+| comma three | 18515968 | anything restored with flash.comma.ai |
+| comma four | 46897152 | `all-partitions.json` in this repo |
+
+comma sizes the partition to the image exactly, so there is never room for a fourth device tree in
+whatever comma last shipped. The comma four's table is not the comma three's: flash.comma.ai reads
+its partition table for a comma three from `commaai/openpilot` branch `release-tici`, which is
+frozen at v0.10.0 and still flashes AGNOS 12.8, so a restored comma three has an 18515968 byte boot
+partition. `boot` is the only entry in the manifest that differs between the two tables; everything
+else, `system` included, fits both.
+
+`agnos.py` writes the decompressed image straight at `/dev/disk/by-partlabel/boot_x`, so an image
+that does not fit is not truncated into something that half works, it simply cannot be written. The
+first image published from this workflow was 47269888 bytes against an 18515968 byte partition. The
+five partitions ahead of `boot` in the manifest flashed, `boot` failed, the slot was never swapped,
+and `launch_chffrplus.sh` re-ran the updater forever. On the car that looks like a device sitting on
+the bootloader splash.
+
+So the image is built gzipped, CI fails the build unless it fits the smaller table, and `agnos.py`
+measures the real partition before writing so a manifest that cannot fit is refused rather than
+leaving the inactive slot half written.
+
+Gzip is not only a size decision. Every AGNOS that has ever booted a comma three shipped a gzip
+kernel, and so do FrogPilot's and StarPilot's rebuilds; the uncompressed `Image-dtb` format, with
+its `UNCOMPRESSED_IMG` header, arrived long after comma stopped building for the board. We pin
+AGNOS 12.8's `abl`, and 12.8 only ever loaded gzip.
 
 ## Running the build
 
@@ -277,6 +321,7 @@ The device is not bricked. The bootloader is running, which means `xbl` and the 
 |---|---|
 | `.github/workflows/zoompilot-agnos-tici-boot.yaml` | the build, package, publish and PR |
 | `scripts/agnos/restore-comma_tici-dts.patch` | the deleted DTS and the one `Makefile` line |
+| `scripts/agnos/gzip_kernel_image.sh` | switches comma's build from `Image-dtb` to `Image.gz-dtb` |
 | `scripts/agnos/manifest_entry.py` | computes and verifies a manifest entry for a flat image |
 | `scripts/agnos/update_manifest.py` | swaps one entry into a manifest |
 | `openpilot/common/hardware/comma/tici_agnos.json` | the comma three's manifest |

--- a/openpilot/common/hardware/comma/agnos.py
+++ b/openpilot/common/hardware/comma/agnos.py
@@ -184,8 +184,27 @@ def extract_compressed_image(target_slot_number: int, partition: dict, cloudlog)
     os.sync()
 
 
+def check_partition_fits(target_slot_number: int, partition: dict) -> None:
+  # A manifest entry larger than the partition cannot be flashed: agnos.py writes
+  # the decompressed image straight at the block device and the write fails at the
+  # end. Refuse before touching anything, so a bad manifest does not leave the
+  # inactive slot half written, and so the reason is in the log.
+  path = get_partition_path(target_slot_number, partition)
+  try:
+    with open(path, 'rb') as f:
+      available = f.seek(0, os.SEEK_END)
+  except OSError:
+    return  # not a block device, e.g. running the updater off device
+
+  if partition['size'] > available:
+    raise Exception(f"{partition['name']} is {partition['size']} bytes, "
+                    f"{partition['size'] - available} more than the {available} byte partition")
+
+
 def flash_partition(target_slot_number: int, partition: dict, cloudlog, standalone=False):
   cloudlog.info(f"Downloading and writing {partition['name']}")
+
+  check_partition_fits(target_slot_number, partition)
 
   if verify_partition(target_slot_number, partition):
     cloudlog.info(f"Already flashed {partition['name']}")

--- a/scripts/agnos/gzip_kernel_image.sh
+++ b/scripts/agnos/gzip_kernel_image.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Package the AGNOS kernel gzip compressed instead of uncompressed.
+#
+# comma's tici_defconfig builds Image-dtb: the uncompressed kernel with every
+# device tree concatenated onto it. At AGNOS 19.7 that image is 46897152 bytes,
+# which is exactly the size of the boot partition, so appending a fourth device
+# tree for the comma three overruns the partition by 372736 bytes. agnos.py
+# writes straight to the block device, so the tail of the kernel is dropped and
+# the device hangs on the bootloader splash.
+#
+# Every AGNOS that ever booted a comma three shipped a gzip image instead, and so
+# does FrogPilot's. The comma three's boot partition was also only 18515968 bytes
+# until comma grew it for the uncompressed images, so a gzip image is the only one
+# that also fits a device whose partition table predates AGNOS 13.
+#
+# This edits comma's checkout in place. Run it after the DTS patch and before
+# build_kernel.sh.
+set -euo pipefail
+
+KERNEL_DIR=${1:?usage: gzip_kernel_image.sh <agnos-kernel-sdm845 dir> <build_kernel.sh>}
+BUILD_SH=${2:?usage: gzip_kernel_image.sh <agnos-kernel-sdm845 dir> <build_kernel.sh>}
+DEFCONFIG="$KERNEL_DIR/arch/arm64/configs/tici_defconfig"
+
+test -f "$DEFCONFIG" || { echo "no such file: $DEFCONFIG" >&2; exit 1; }
+test -f "$BUILD_SH"  || { echo "no such file: $BUILD_SH" >&2; exit 1; }
+
+# Fail loudly rather than silently no-op if comma has already moved these. The
+# whole point of the script is that the build stops producing Image-dtb.
+for want in \
+  '# CONFIG_IMG_GZ_DTB is not set' \
+  'CONFIG_IMG_DTB=y' \
+  'CONFIG_BUILD_ARM64_APPENDED_KERNEL_IMAGE_NAME="Image-dtb"' \
+  '# CONFIG_BUILD_ARM64_KERNEL_COMPRESSION_GZIP is not set' \
+  'CONFIG_BUILD_ARM64_UNCOMPRESSED_KERNEL=y'
+do
+  grep -qxF "$want" "$DEFCONFIG" || {
+    echo "tici_defconfig no longer contains: $want" >&2
+    echo "comma changed how the kernel image is packaged; re-derive this script" >&2
+    exit 1
+  }
+done
+
+# BUILD_ARM64_KERNEL_COMPRESSION_GZIP is the one that picks the target in
+# arch/arm64/Makefile. IMG_GZ_DTB only feeds the NAME string, but leaving the two
+# disagreeing would be a trap for the next person reading the config.
+sed -i.bak \
+  -e 's/^# CONFIG_IMG_GZ_DTB is not set$/CONFIG_IMG_GZ_DTB=y/' \
+  -e 's/^CONFIG_IMG_DTB=y$/# CONFIG_IMG_DTB is not set/' \
+  -e 's/^CONFIG_BUILD_ARM64_APPENDED_KERNEL_IMAGE_NAME="Image-dtb"$/CONFIG_BUILD_ARM64_APPENDED_KERNEL_IMAGE_NAME="Image.gz-dtb"/' \
+  -e 's/^# CONFIG_BUILD_ARM64_KERNEL_COMPRESSION_GZIP is not set$/CONFIG_BUILD_ARM64_KERNEL_COMPRESSION_GZIP=y/' \
+  -e 's/^CONFIG_BUILD_ARM64_UNCOMPRESSED_KERNEL=y$/# CONFIG_BUILD_ARM64_UNCOMPRESSED_KERNEL is not set/' \
+  "$DEFCONFIG"
+rm -f "$DEFCONFIG.bak"
+
+for want in \
+  'CONFIG_IMG_GZ_DTB=y' \
+  '# CONFIG_IMG_DTB is not set' \
+  'CONFIG_BUILD_ARM64_APPENDED_KERNEL_IMAGE_NAME="Image.gz-dtb"' \
+  'CONFIG_BUILD_ARM64_KERNEL_COMPRESSION_GZIP=y' \
+  '# CONFIG_BUILD_ARM64_UNCOMPRESSED_KERNEL is not set'
+do
+  grep -qxF "$want" "$DEFCONFIG" || { echo "defconfig edit did not take: $want" >&2; exit 1; }
+done
+
+# build_kernel.sh names Image-dtb twice, to copy it out of the kernel tree and to
+# hand it to mkbootimg. Image.gz-dtb does not contain the string Image-dtb, so
+# this is idempotent.
+sed -i.bak 's/Image-dtb/Image.gz-dtb/g' "$BUILD_SH"
+rm -f "$BUILD_SH.bak"
+
+grep -q -- '--kernel Image\.gz-dtb' "$BUILD_SH" || { echo "mkbootimg is not being given Image.gz-dtb" >&2; exit 1; }
+grep -q 'boot/Image\.gz-dtb' "$BUILD_SH"        || { echo "build_kernel.sh does not copy out Image.gz-dtb" >&2; exit 1; }
+if grep -v 'Image\.gz-dtb' "$BUILD_SH" | grep -q 'Image-dtb'; then
+  echo "build_kernel.sh still refers to Image-dtb somewhere" >&2
+  exit 1
+fi
+
+echo "kernel image will be built and packaged as Image.gz-dtb"


### PR DESCRIPTION
The first tici boot image this workflow published could not be flashed at all. It
was packaged uncompressed, as comma's current `tici_defconfig` asks for, and came
out 47269888 bytes. A comma three's boot partition is 18515968 bytes.

`agnos.py` writes the decompressed image straight at `/dev/disk/by-partlabel/boot_x`,
so the five partitions ahead of `boot` in the manifest flashed, `boot` could not be
written, the slot was never swapped, and `launch_chffrplus.sh` re-ran the updater
forever. On the car that looks like a device sitting on the bootloader splash, which
is what a tester reported.

Two things were wrong at once:

- comma stopped compressing the kernel at AGNOS 19 (`f899166`). Their uncompressed
  image is 46897152 bytes, exactly 100% of a comma four's boot partition, so there
  was never room for a fourth device tree even on the larger layout.
- the larger layout is not what a comma three has. flash.comma.ai reads its partition
  table from `commaai/openpilot` branch `release-tici`, frozen at v0.10.0, which
  still flashes AGNOS 12.8 and its 18515968 byte boot partition.

Build `Image.gz-dtb` instead. Same kernel, same four device trees, same signing key.
That is what every AGNOS that ever booted a comma three shipped, and what FrogPilot's
and StarPilot's rebuilds ship, so it is also the only format the AGNOS 12.8 `abl` we
pin is known to load. The result is 17864704 bytes.

Guards so this cannot recur: CI fails the build unless the image fits the comma
three's table, and `agnos.py` measures the real partition before writing so a
manifest that cannot fit is refused instead of leaving the inactive slot half
written.

Verified out of the published release asset: single xz stream, sha256 matches the
filename, gzip kernel, all four device trees present with `comma tici` at board-id
`0x8 0x0 0x20 0x0`.