### PR TITLE
ui: optionally show the active driving model on the home screen

### DIFF
--- a/openpilot/common/params_keys.h
+++ b/openpilot/common/params_keys.h
@@ -172,6 +172,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"GithubRunnerSufficientVoltage", {CLEAR_ON_MANAGER_START , BOOL}},
     {"HasAcceptedTermsSP", {PERSISTENT, STRING, "0"}},
     {"HideVEgoUI", {PERSISTENT | BACKUP, BOOL, "0"}},
+    {"HomeShowActiveModel", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"IntelligentCruiseButtonManagement", {PERSISTENT | BACKUP , BOOL}},
     {"InteractivityTimeout", {PERSISTENT | BACKUP, INT, "0"}},
     {"IsDevelopmentBranch", {CLEAR_ON_MANAGER_START, BOOL}},

--- a/openpilot/selfdrive/ui/sunnypilot/active_model.py
+++ b/openpilot/selfdrive/ui/sunnypilot/active_model.py
@@ -1,0 +1,36 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+import re
+
+from openpilot.selfdrive.ui.ui_state import ui_state
+from openpilot.sunnypilot.models.default_model import get_default_model
+from openpilot.sunnypilot.models.helpers import get_active_bundle
+
+RELEASE_DATE = re.compile(r"\s*\([^()]*\)\s*$")
+
+_offroad_name: str | None = None
+
+
+def active_model_name() -> str:
+  """The driving model modeld is running, without its release date.
+
+  models_manager only runs offroad, so a UI that came up onroad never receives modelManagerSP.
+  There the name comes from the same ModelManager_ActiveBundle param modeld itself reads,
+  instead of falling back to the default name and confidently naming the wrong model.
+  """
+  global _offroad_name
+
+  if ui_state.sm.recv_frame["modelManagerSP"] > 0:
+    bundle = ui_state.sm["modelManagerSP"].activeBundle
+    name = bundle.displayName if bundle.ref else get_default_model()
+  else:
+    if _offroad_name is None:
+      bundle = get_active_bundle(ui_state.params)
+      _offroad_name = bundle.displayName if bundle else get_default_model()
+    name = _offroad_name
+
+  return RELEASE_DATE.sub("", name)

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/home.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/home.py
@@ -6,6 +6,8 @@ See the LICENSE.md file in the root directory for more details.
 """
 import pyray as rl
 from openpilot.selfdrive.ui.layouts.home import HomeLayout, HomeLayoutState, HEAD_BUTTON_FONT_SIZE, SPACING
+from openpilot.selfdrive.ui.sunnypilot.active_model import active_model_name
+from openpilot.selfdrive.ui.ui_state import ui_state
 from openpilot.system.ui.lib.application import gui_app, FontWeight, TextAlignment
 from openpilot.system.ui.lib.text_measure import measure_text_cached
 from openpilot.system.ui.lib.multilang import tr, trn
@@ -13,6 +15,9 @@ from openpilot.system.ui.widgets.label import gui_label
 
 BRAND_FONT_SIZE = 48
 BRAND_DESC_SPACING = 12
+MODEL_FONT_SIZE = 32
+MODEL_GAP = 24
+MODEL_COLOR = rl.Color(255, 255, 255, int(255 * 0.65))
 
 
 class HomeLayoutSP(HomeLayout):
@@ -66,3 +71,13 @@ class HomeLayoutSP(HomeLayout):
     brand_x = version_right - desc_width - spacing - brand_size.x
     brand_rect = rl.Rectangle(max(version_left, brand_x), self.header_rect.y, brand_size.x, self.header_rect.height)
     gui_label(brand_rect, brand, BRAND_FONT_SIZE, rl.WHITE, font_weight=FontWeight.AUDIOWIDE)
+
+    # The model name shares the header row rather than taking one of its own: the row is a fixed
+    # HEADER_HEIGHT and a second line would clip. It sits left of the brand and gives way to it,
+    # so a long name elides instead of colliding.
+    if ui_state.home_show_active_model:
+      model_right = brand_rect.x - MODEL_GAP
+      model_rect = rl.Rectangle(version_left, self.header_rect.y,
+                                model_right - version_left, self.header_rect.height)
+      if model_rect.width > 0:
+        gui_label(model_rect, active_model_name(), MODEL_FONT_SIZE, MODEL_COLOR, alignment=TextAlignment.RIGHT)

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/settings/display.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/settings/display.py
@@ -61,6 +61,11 @@ class DisplayLayout(Widget):
                                     f"{value} s" if value < 60 else f"{int(value/60)} m"),
       inline=True
     )
+    self._home_model_toggle = toggle_item_sp(
+      param="HomeShowActiveModel",
+      title=lambda: tr("Show Driving Model on Home Screen"),
+      description=lambda: tr("Name the active driving model on the offroad home screen."),
+    )
     self._screensaver_toggle = toggle_item_sp(
       param="ScreenSaverEnabled",
       title=lambda: tr("Screen Saver"),
@@ -79,6 +84,7 @@ class DisplayLayout(Widget):
       self._onroad_brightness,
       self._onroad_brightness_timer,
       self._interactivity_timeout,
+      self._home_model_toggle,
       self._screensaver_toggle,
       self._screensaver_timeout,
     ]

--- a/openpilot/selfdrive/ui/sunnypilot/mici/layouts/display.py
+++ b/openpilot/selfdrive/ui/sunnypilot/mici/layouts/display.py
@@ -87,6 +87,8 @@ class DisplayLayoutMici(NavScroller):
       picker_unit=tr("seconds"),
     )
 
+    self._home_model = BigParamControl(tr("model on home"), "HomeShowActiveModel")
+
     self._screensaver = BigParamControl(tr("screen saver"), "ScreenSaverEnabled")
     # Match the TICI screen-saver range and one-minute step.
     self._screensaver_timeout = BigParamOption(
@@ -98,13 +100,14 @@ class DisplayLayoutMici(NavScroller):
     )
 
     self._scroller.add_widgets([self._brightness, self._brightness_timer, self._ui_timeout,
-                                self._screensaver, self._screensaver_timeout])
+                                self._home_model, self._screensaver, self._screensaver_timeout])
 
   def _update_state(self):
     super()._update_state()
     self._brightness.refresh()
     self._brightness_timer.refresh()
     self._ui_timeout.refresh()
+    self._home_model.refresh()
     self._screensaver.refresh()
     self._screensaver_timeout.refresh()
 

--- a/openpilot/selfdrive/ui/sunnypilot/mici/layouts/home.py
+++ b/openpilot/selfdrive/ui/sunnypilot/mici/layouts/home.py
@@ -8,10 +8,16 @@ import math
 
 import pyray as rl
 
-from openpilot.selfdrive.ui.mici.layouts.home import MiciHomeLayout
+from openpilot.selfdrive.ui.mici.layouts.home import MiciHomeLayout, HOME_PADDING
+from openpilot.selfdrive.ui.sunnypilot.active_model import active_model_name
 from openpilot.selfdrive.ui.ui_state import ui_state, ChestnutState
-from openpilot.system.ui.lib.application import FontWeight
-from openpilot.system.ui.widgets.label import UnifiedLabel
+from openpilot.system.ui.lib.application import FontWeight, TextAlignment
+from openpilot.system.ui.widgets.label import UnifiedLabel, gui_label
+
+MODEL_FONT_SIZE = 32
+MODEL_ROW_HEIGHT = 48
+MODEL_ICON_GAP = 24
+MODEL_COLOR = rl.Color(255, 255, 255, int(255 * 0.9 * 0.65))
 
 
 class MiciHomeLayoutSP(MiciHomeLayout):
@@ -31,3 +37,24 @@ class MiciHomeLayoutSP(MiciHomeLayout):
     self._chestnut_icon.set_visible(not usb_unknown and not loading and
                                     chestnut_state in (ChestnutState.READY, ChestnutState.ACTIVE))
     self._chestnut_failed_icon.set_visible(not usb_unknown and chestnut_state in (ChestnutState.UNCOMPILED, ChestnutState.FAILED))
+
+  def _render(self, rect):
+    super()._render(rect)
+    if ui_state.home_show_active_model:
+      self._render_model_name()
+
+  def _render_model_name(self):
+    icons = [widget for widget in self._status_bar_layout.widgets if widget.is_visible]
+    left = icons[-1].rect.x + icons[-1].rect.width if icons else self.rect.x
+
+    right = self.rect.x + self.rect.width - HOME_PADDING
+    if self._alert_count_callback and self._alert_count_callback() > 0:
+      right -= self._alerts_pill.rect.width + HOME_PADDING
+
+    name_rect = rl.Rectangle(left + MODEL_ICON_GAP, self.rect.y + self.rect.height - MODEL_ROW_HEIGHT,
+                             right - left - MODEL_ICON_GAP, MODEL_ROW_HEIGHT)
+    if name_rect.width <= 0:
+      return
+
+    gui_label(name_rect, active_model_name().lower(), MODEL_FONT_SIZE, MODEL_COLOR, FontWeight.ROMAN,
+              alignment=TextAlignment.RIGHT)

--- a/openpilot/selfdrive/ui/sunnypilot/mici/tests/test_mici_settings.py
+++ b/openpilot/selfdrive/ui/sunnypilot/mici/tests/test_mici_settings.py
@@ -494,3 +494,18 @@ class TestLayoutsSurviveRender:
     from openpilot.selfdrive.ui.sunnypilot.mici.layouts.home import MiciHomeLayoutSP
 
     render(MiciHomeLayoutSP())
+
+  @pytest.mark.parametrize("show_model", [False, True])
+  def test_home_layouts_render_with_the_model_name(self, params, show_model):
+    # HomeShowActiveModel gates a draw the default-off path never reaches, so the on path
+    # needs rendering too or the toggle ships untested. Both UIs draw it, mici on its footer
+    # row and tici on the header row, so both are checked here.
+    from openpilot.selfdrive.ui.sunnypilot.mici.layouts.home import MiciHomeLayoutSP
+    from openpilot.selfdrive.ui.sunnypilot.layouts.home import HomeLayoutSP
+    from openpilot.selfdrive.ui.ui_state import ui_state
+
+    params.put_bool("HomeShowActiveModel", show_model, block=True)
+    ui_state.update_params()
+    assert ui_state.home_show_active_model == show_model
+    render(MiciHomeLayoutSP())
+    render(HomeLayoutSP())

--- a/openpilot/selfdrive/ui/sunnypilot/ui_state.py
+++ b/openpilot/selfdrive/ui/sunnypilot/ui_state.py
@@ -50,6 +50,7 @@ class UIStateSP:
     self.custom_interactive_timeout: int = 0
     self.developer_ui = None
     self.hide_v_ego_ui: bool = False
+    self.home_show_active_model: bool = False
     self.onroad_brightness: int = 0
     self.onroad_brightness_timer: int = 0
     self.onroad_brightness_timer_param: int = 0
@@ -164,6 +165,7 @@ class UIStateSP:
     self.custom_interactive_timeout = self.params.get("InteractivityTimeout", return_default=True)
     self.developer_ui = self.params.get("DevUIInfo")
     self.hide_v_ego_ui = self.params.get_bool("HideVEgoUI")
+    self.home_show_active_model = self.params.get_bool("HomeShowActiveModel")
     self.onroad_brightness = int(float(self.params.get("OnroadScreenOffBrightness", return_default=True)))
     self.onroad_brightness_timer_param = self.params.get("OnroadScreenOffTimer", return_default=True)
     self.rainbow_path = self.params.get_bool("RainbowMode")

--- a/openpilot/sunnypilot/sunnylink/settings_ui.json
+++ b/openpilot/sunnypilot/sunnylink/settings_ui.json
@@ -1382,6 +1382,12 @@
               ]
             },
             {
+              "key": "HomeShowActiveModel",
+              "widget": "toggle",
+              "title": "Show Driving Model on Home Screen",
+              "description": "Name the active driving model on the offroad home screen."
+            },
+            {
               "key": "ScreenSaverEnabled",
               "widget": "toggle",
               "title": "Screen Saver",

--- a/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/display.yaml
+++ b/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/display.yaml
@@ -128,6 +128,10 @@ sections:
       label: 1 m
     - value: 120
       label: 2 m
+  - key: HomeShowActiveModel
+    widget: toggle
+    title: Show Driving Model on Home Screen
+    description: Name the active driving model on the offroad home screen.
   - key: ScreenSaverEnabled
     widget: toggle
     title: Screen Saver


### PR DESCRIPTION
## Problem

The home screen does not show which driving model is selected. Checking it means opening the models settings page.

## Fix

- New Display toggle "Show Driving Model on Home Screen" (`HomeShowActiveModel`, default off) on the tici and mici display pages and in the sunnylink display page source, with `settings_ui.json` updated to match.
- mici draws the name on the footer row, right aligned and lowercase, in the gray the version line uses, and moves it left of the alerts pill while offroad alerts are up. tici draws it on the header row left of the brand, since that row has a fixed height and a second line would clip. A name that does not fit is elided.
- The name comes from `modelManagerSP`, the source the models settings page reads, with the release date in parentheses dropped. `models_manager` only runs offroad, so a UI that starts onroad never receives that message; there the name is read once from `ModelManager_ActiveBundle`, the param modeld loads, instead of falling back to the default model's name.
- The toggle is read in `UIStateSP.update_params` with the other display settings.

## Validation

- Host: `test_home_layouts_render_with_the_model_name` renders both home layouts with the toggle off and on. With `active_model_name()` changed to raise, only the toggle on case fails, so that case reaches the new drawing code. The other 18 failures in `test_mici_settings.py` are the same on develop (`mici/widgets/button.py` uses `rl.GuiTextAlignmentVertical`, which the locked pyray does not have). `ruff check` clean.
- sunnylink tests: 70 passed. `test_compiled_matches_committed` and `test_committed_file_is_canonical` fail on develop too, from the existing `MazdaTjaButton` drift between `settings_ui.json` and the page sources, which this does not touch.
- Device (comma four): the model name shows on the home screen with the toggle on.

<img width="536" height="240" alt="mici-home-model" src="https://github.com/user-attachments/assets/86c1f613-0dd0-42f1-ba16-ef738838d415" />
<img width="536" height="240" alt="mici-home-model-long" src="https://github.com/user-attachments/assets/38a565c0-ab61-4780-91c6-f3e3b4a06089" />
<img width="2160" height="200" alt="tici-home-model" src="https://github.com/user-attachments/assets/9c239868-67b7-4764-8561-32c2bd4458c1" />
<img width="2160" height="200" alt="tici-home-model-long" src="https://github.com/user-attachments/assets/67562bf8-c7a2-4348-8dfa-d6a6fc0d1aa7" />


## AI Usage

Disclaimer: Claude Opus 5 by Anthropic was used to help develop, debug, and document this submission. All changes were reviewed and validated by a human.
