### PR TITLE
mazda: cylinder deactivation status UI

### DIFF
--- a/openpilot/cereal/custom.capnp
+++ b/openpilot/cereal/custom.capnp
@@ -578,6 +578,28 @@ struct CarStateZP @0xc879af11c43cb400 {
       dismiss @5;
     }
   }
+
+  # Engine cylinder mode, filled by the Mazda port from MORE_GAS (0x167) byte 7.
+  # entry is the PCM's confirmation ramp before deactivation latches (about 1.2 s);
+  # entryProgress tracks that ramp 0..1 so a UI can show deactivation incoming.
+  # engineBraking is inferred from pedal-up and engine coupling only; there is no
+  # decel gate, because fuel cut survives grades where the car holds speed. The
+  # PCM byte reports "all cylinders" during fuel cut, so that state cannot come
+  # from the byte itself.
+  # Stays normal on engines without deactivation hardware.
+  cylinderDeactivation @2 :CylinderDeactivation;
+
+  struct CylinderDeactivation {
+    state @0 :State;
+    entryProgress @1 :Float32;      # 0..1 while state == entry, 1.0 while deactivated
+
+    enum State {
+      normal @0;                    # all cylinders firing (idle, drive, fuel cut per the byte)
+      entry @1;                     # deactivation pending, PCM confirmation ramp
+      deactivated @2;               # two cylinders firing
+      engineBraking @3;             # inferred coast in gear, pedal up and coupled; fuel cut likely, not confirmed
+    }
+  }
 }
 
 struct CarControlZP @0xaadf9bc39b7bd41e {

--- a/openpilot/common/params_keys.h
+++ b/openpilot/common/params_keys.h
@@ -163,6 +163,7 @@ inline static std::unordered_map<std::string, ParamKeyAttributes> keys = {
     {"CustomAccIncrementsEnabled", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"CustomAccLongPressIncrement", {PERSISTENT | BACKUP, INT, "5"}},
     {"CustomAccShortPressIncrement", {PERSISTENT | BACKUP, INT, "1"}},
+    {"CylinderDeactivationUI", {PERSISTENT | BACKUP, BOOL, "0"}},
     {"DeviceBootMode", {PERSISTENT | BACKUP, INT, "0"}},
     {"DevUIInfo", {PERSISTENT | BACKUP, INT, "0"}},
     {"EnableCopyparty", {PERSISTENT | BACKUP, BOOL}},

--- a/openpilot/selfdrive/car/card.py
+++ b/openpilot/selfdrive/car/card.py
@@ -221,6 +221,7 @@ class Car:
       # Use CarState w/ buttons from the step selfdrived enables on
       self.v_cruise_helper.initialize_v_cruise(self.CS_prev, self.experimental_mode, self.dynamic_experimental_control)
     self.card_ext.update_v_cruise_post(CS, CS_SP)
+    self.card_ext.fill_cylinder_deactivation(CS_SP)
 
     # TODO: mirror the carState.cruiseState struct?
     CS.vCruise = float(self.v_cruise_helper.v_cruise_kph)

--- a/openpilot/selfdrive/ui/sunnypilot/layouts/settings/visuals.py
+++ b/openpilot/selfdrive/ui/sunnypilot/layouts/settings/visuals.py
@@ -6,6 +6,7 @@ See the LICENSE.md file in the root directory for more details.
 """
 from openpilot.common.params import Params
 from openpilot.selfdrive.ui.ui_state import ui_state
+from openpilot.sunnypilot.mads.helpers import offroad_brand
 from openpilot.system.ui.lib.multilang import tr, tr_noop
 from openpilot.system.ui.sunnypilot.widgets.list_view import toggle_item_sp, multiple_button_item_sp
 from openpilot.system.ui.widgets.scroller_tici import Scroller
@@ -93,6 +94,11 @@ class VisualsLayout(Widget):
            "This displays what the car is currently doing, not what the planner is requesting."),
         None,
       ),
+      "CylinderDeactivationUI": (
+        lambda: tr("Cylinder Status Ring"),
+        tr("Ring showing cylinder deactivation and engine braking status."),
+        None,
+      ),
     }
     self._toggles = {}
     for param, (title, desc, callback) in self._toggle_defs.items():
@@ -104,6 +110,10 @@ class VisualsLayout(Widget):
         callback=callback,
       )
       self._toggles[param] = toggle
+
+    # the ring wraps the driver-monitoring circle, which only Mazda cars have
+    self._toggles["CylinderDeactivationUI"].set_visible(
+      lambda: offroad_brand(ui_state.params, ui_state.CP, ui_state.is_offroad()) == "mazda")
 
     self._chevron_info = multiple_button_item_sp(
       title=lambda: tr("Display Metrics Below Chevron"),

--- a/openpilot/selfdrive/ui/sunnypilot/mici/onroad/hud_renderer.py
+++ b/openpilot/selfdrive/ui/sunnypilot/mici/onroad/hud_renderer.py
@@ -8,18 +8,26 @@ import pyray as rl
 
 from openpilot.selfdrive.ui.mici.onroad.hud_renderer import HudRenderer
 from openpilot.selfdrive.ui.sunnypilot.onroad.blind_spot_indicators import BlindSpotIndicators
+from openpilot.selfdrive.ui.sunnypilot.onroad.cylinder_deactivation import CylinderDeactivationRenderer
+from openpilot.selfdrive.ui.ui_state import ui_state
 
 
 class HudRendererSP(HudRenderer):
   def __init__(self):
     super().__init__()
     self.blind_spot_indicators = BlindSpotIndicators()
+    # the ring wraps the steering-wheel icon: same anchor, inner edge at the
+    # wheel's edge
+    self.cylinder_deactivation = CylinderDeactivationRenderer(
+      inner_r=25.0, outer_r=38.0, corner_x=46.0, corner_y=39.0)
 
   def _update_state(self) -> None:
     super()._update_state()
     self.blind_spot_indicators.update()
 
   def _render(self, rect: rl.Rectangle) -> None:
+    # the ring draws first so the torque bar and the wheel icon stay on top of it
+    self.cylinder_deactivation.render(rect, ui_state.sm)
     super()._render(rect)
     self.blind_spot_indicators.render(rect)
 

--- a/openpilot/selfdrive/ui/sunnypilot/onroad/cylinder_deactivation.py
+++ b/openpilot/selfdrive/ui/sunnypilot/onroad/cylinder_deactivation.py
@@ -1,0 +1,137 @@
+"""
+Copyright (c) 2021-, Haibin Wen, sunnypilot, and a number of other contributors.
+
+This file is part of sunnypilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+import time
+
+import pyray as rl
+
+from openpilot.cereal import custom
+from openpilot.selfdrive.ui import UI_BORDER_SIZE
+from openpilot.selfdrive.ui.onroad.driver_state import BTN_SIZE
+from openpilot.selfdrive.ui.ui_state import ui_state
+
+# The gauge shows cylinder status: two arcs grow clockwise as the PCM ramps
+# toward deactivation, the latch holds two opposite quadrant arcs (2 of 4
+# cylinders), and fuel cut spins four dashes counter-clockwise (drag). State
+# changes crossfade; on the return to all-cylinder operation the last look
+# fades out and the gauge hides. A black bed under the gauge keeps it
+# readable over any road. The gauge only draws with the user toggle on; cars
+# without deactivation hardware never leave normal, so it stays hidden
+# without a setting either way.
+#
+# The default ring wraps the driver-monitoring circle: same center as the
+# icon, inner edge at the icon boundary. Mici passes smaller radii centered
+# on its steering-wheel icon.
+_DM_RADIUS = BTN_SIZE // 2
+_DM_CENTER_OFFSET = UI_BORDER_SIZE + _DM_RADIUS
+RING_INNER_R = float(_DM_RADIUS)
+RING_OUTER_R = float(_DM_RADIUS + 24)
+CORNER_OFFSET = float(_DM_CENTER_OFFSET)
+
+# Turbine encoding: clockwise motion means load, counter-clockwise means drag.
+QUAD_DEG = 90.0
+LATCH_ARCS = ((-90.0, 0.0), (90.0, 180.0))  # raylib angles: top-right, bottom-left
+CUT_DASH_COUNT = 4
+CUT_SPAN_DEG = 45.0
+CUT_PERIOD_S = 3.0  # seconds per counter-clockwise revolution
+STATE_FADE_S = 0.3  # crossfade when the gauge switches states
+
+STATE = custom.CarStateZP.CylinderDeactivation.State
+
+RING_ACTIVE = rl.Color(0x4f, 0xd0, 0x84, 0xff)  # cylinders firing
+RING_CUT = rl.Color(0x53, 0x9f, 0xc7, 0xff)     # fuel cut: no cylinders firing
+
+
+def _alpha(color: rl.Color, a: int) -> rl.Color:
+  return rl.Color(color.r, color.g, color.b, color.a * a // 255)
+
+
+class CylinderDeactivationRenderer:
+  def __init__(self, inner_r: float = RING_INNER_R, outer_r: float = RING_OUTER_R,
+               corner_x: float = CORNER_OFFSET, corner_y: float = CORNER_OFFSET):
+    self._inner_r = inner_r
+    self._outer_r = outer_r
+    self._corner_x = corner_x
+    self._corner_y = corner_y
+    self._last_state = STATE.normal
+    self._prev_state = STATE.normal
+    self._state_changed_t = 0.0
+    self._vignette_a = 0
+    self._progress = 0.0         # the ramp the current state last drew with
+    self._prev_progress = 0.0    # latched at a transition, for the outgoing state's fade
+
+  def render(self, rect: rl.Rectangle, sm) -> None:
+    if not ui_state.cylinder_deactivation_ui:
+      return
+
+    cd = sm['carStateSP'].zoompilot.cylinderDeactivation
+    state = cd.state
+    now = time.monotonic()
+
+    if state != self._last_state:
+      self._prev_state = self._last_state
+      # the decode resets entryProgress the same frame it leaves entry, so latch the
+      # ramp the outgoing state was drawn with or its fade-out draws nothing
+      self._prev_progress = self._progress
+      self._last_state = state
+      self._state_changed_t = now
+    fade = max(0.0, min(1.0, (now - self._state_changed_t) / STATE_FADE_S))
+    progress = max(0.0, min(1.0, float(cd.entryProgress)))
+    self._progress = progress
+
+    center = rl.Vector2(int(rect.x + self._corner_x), int(rect.y + rect.height - self._corner_y))
+
+    if state == STATE.normal:
+      # fade the previous state and its bed out, then hide
+      if self._prev_state == STATE.normal or fade >= 1.0:
+        return
+      a = int(255 * (1.0 - fade))
+      self._draw_vignette(center, a)
+      self._draw_state(self._prev_state, center, a, self._prev_progress, now)
+      return
+
+    if state == STATE.entry:
+      # the bed fades in with the ramp, like the bars
+      self._vignette_a = int(255 * progress)
+    elif self._prev_state == STATE.normal:
+      # entering a visible state from hidden: fade the bed in with the state
+      self._vignette_a = int(255 * fade)
+    else:
+      self._vignette_a = 255
+
+    self._draw_vignette(center, self._vignette_a)
+    if self._prev_state not in (STATE.normal, state) and fade < 1.0:
+      self._draw_state(self._prev_state, center, int(255 * (1.0 - fade)), self._prev_progress, now)
+    self._draw_state(state, center, int(255 * fade), progress, now)
+
+  def _draw_vignette(self, center: rl.Vector2, alpha: int) -> None:
+    if alpha <= 0:
+      return
+    # black annulus filling the zone between the icon and the ring, capped
+    # flush at the ring's outer edge; the icon interior is never darkened
+    rl.draw_ring(center, self._inner_r, self._outer_r, 0, 360, 64, rl.Color(0, 0, 0, alpha))
+
+  def _draw_state(self, state, center: rl.Vector2, alpha: int, progress: float, now: float) -> None:
+    if state == STATE.normal or alpha <= 0:
+      return
+
+    if state == STATE.entry:
+      # two arcs grow clockwise from 12 and 6 o'clock, fading in with the ramp
+      p = max(0.0, min(1.0, progress))
+      if p <= 0:
+        return
+      color = _alpha(RING_ACTIVE, int(alpha * p))
+      for start in (-90.0, 90.0):
+        rl.draw_ring(center, self._inner_r, self._outer_r, start, start + QUAD_DEG * p, 24, color)
+    elif state == STATE.deactivated:
+      for start, end in LATCH_ARCS:
+        rl.draw_ring(center, self._inner_r, self._outer_r, start, end, 24, _alpha(RING_ACTIVE, alpha))
+    elif state == STATE.engineBraking:
+      # four dashes spin counter-clockwise: drag, not load
+      off = -360.0 * (now % CUT_PERIOD_S) / CUT_PERIOD_S
+      for k in range(CUT_DASH_COUNT):
+        a0 = -90 + 90 * k + off
+        rl.draw_ring(center, self._inner_r, self._outer_r, a0, a0 + CUT_SPAN_DEG, 16, _alpha(RING_CUT, alpha))

--- a/openpilot/selfdrive/ui/sunnypilot/onroad/hud_renderer.py
+++ b/openpilot/selfdrive/ui/sunnypilot/onroad/hud_renderer.py
@@ -8,6 +8,7 @@ import pyray as rl
 
 from openpilot.common.constants import CV
 from openpilot.selfdrive.ui.mici.onroad.torque_bar import TorqueBar
+from openpilot.selfdrive.ui.sunnypilot.onroad.cylinder_deactivation import CylinderDeactivationRenderer
 from openpilot.selfdrive.ui.sunnypilot.onroad.developer_ui import DeveloperUiRenderer, DeveloperUiState, get_bottom_dev_ui_offset
 from openpilot.selfdrive.ui.sunnypilot.onroad.road_name import RoadNameRenderer
 from openpilot.selfdrive.ui.sunnypilot.onroad.rocket_fuel import RocketFuel
@@ -36,6 +37,7 @@ class HudRendererSP(HudRenderer):
     self.turn_signal_controller = TurnSignalController()
     self.circular_alerts_renderer = CircularAlertsRenderer()
     self.speed_renderer = SpeedRenderer()
+    self.cylinder_deactivation = CylinderDeactivationRenderer()
     self._torque_bar = TorqueBar(scale=3.0, always=True)
 
     self.pcm_cruise_speed: bool = True
@@ -129,6 +131,8 @@ class HudRendererSP(HudRenderer):
     self.speed_renderer.render(rect)
 
   def _render(self, rect: rl.Rectangle) -> None:
+    # the ring draws first so later HUD elements stay on top of it, matching mici
+    self.cylinder_deactivation.render(rect, ui_state.sm)
     super()._render(rect)
 
     if ui_state.torque_bar:

--- a/openpilot/selfdrive/ui/sunnypilot/ui_state.py
+++ b/openpilot/selfdrive/ui/sunnypilot/ui_state.py
@@ -48,6 +48,7 @@ class UIStateSP:
     self.blindspot: bool = False
     self.chevron_metrics = None
     self.custom_interactive_timeout: int = 0
+    self.cylinder_deactivation_ui: bool = False
     self.developer_ui = None
     self.hide_v_ego_ui: bool = False
     self.onroad_brightness: int = 0
@@ -161,6 +162,7 @@ class UIStateSP:
     self.chestnut_compiled = self.chestnut_compiled or self.model_runner_tinygrad
     self.blindspot = self.params.get_bool("BlindSpot")
     self.chevron_metrics = self.params.get("ChevronInfo")
+    self.cylinder_deactivation_ui = self.params.get_bool("CylinderDeactivationUI")
     self.custom_interactive_timeout = self.params.get("InteractivityTimeout", return_default=True)
     self.developer_ui = self.params.get("DevUIInfo")
     self.hide_v_ego_ui = self.params.get_bool("HideVEgoUI")

--- a/openpilot/sunnypilot/selfdrive/car/card_ext.py
+++ b/openpilot/sunnypilot/selfdrive/car/card_ext.py
@@ -21,6 +21,7 @@ class CardExt:
   def __init__(self, CP: structs.CarParams, CP_SP: structs.CarParamsSP, params: Params, sm, v_cruise_helper, CI) -> None:
     self.sm = sm
     self.v_cruise_helper = v_cruise_helper
+    self.CI = CI
     # The stock ECU transition contract (opendbc/sunnypilot/car/stock_ecu.py): a controller that
     # silences a stock ECU under openpilot longitudinal exposes `stock_ecu_state`; nothing
     # brand-specific is read here. The hand-back server answers the lifecycle's requests off it.
@@ -40,6 +41,14 @@ class CardExt:
   @property
   def stock_ecu_state(self) -> StockEcuState:
     return getattr(self.controller, "stock_ecu_state", StockEcuState.NOT_NEEDED)
+
+  def fill_cylinder_deactivation(self, CS_SP) -> None:
+    # The Mazda port computes the cylinder status from MORE_GAS; publish it next to
+    # cruiseSession the same way. Only Mazda's CarState carries it, so hold the
+    # all-cylinder default everywhere else (the stock_ecu_state pattern above).
+    cyl = CS_SP.zoompilot.cylinderDeactivation
+    cyl.state = str(getattr(self.CI.CS, "cyl_state", "normal"))
+    cyl.entryProgress = float(getattr(self.CI.CS, "cyl_entry_progress", 0.0))
 
   def controls_update(self, CS, CC, CC_SP: structs.CarControlSP) -> structs.CarControlSP:
     """Runs just before CI.apply on the converted CarControlSP struct, which it may edit."""

--- a/openpilot/sunnypilot/selfdrive/car/tests/test_card_ext.py
+++ b/openpilot/sunnypilot/selfdrive/car/tests/test_card_ext.py
@@ -1,0 +1,42 @@
+"""
+Copyright (c) 2026-, Zeph Leggett.
+
+This file is part of zoompilot and is licensed under the MIT License.
+See the LICENSE.md file in the root directory for more details.
+"""
+from types import SimpleNamespace
+
+from opendbc.car import structs
+from openpilot.cereal import custom
+from openpilot.sunnypilot.selfdrive.car.card_ext import CardExt
+from openpilot.sunnypilot.selfdrive.car.tests.fakes import FakeParams
+
+
+def _card_ext(CS: SimpleNamespace) -> CardExt:
+  CI = SimpleNamespace(CS=CS, CC=SimpleNamespace())
+  return CardExt(structs.CarParams(), structs.CarParamsSP(), FakeParams(), None, None, CI)
+
+
+def _car_state_sp():
+  return custom.CarStateSP.new_message()
+
+
+class TestFillCylinderDeactivation:
+  def test_car_state_without_cylinder_fields_publishes_the_default(self):
+    # only the Mazda CarStateExt carries cyl_state; every other brand (and the brands
+    # with no CarStateExt at all) must publish normal/0.0 instead of raising, or card
+    # dies on the first frame
+    ext = _card_ext(SimpleNamespace())
+    CS_SP = _car_state_sp()
+    ext.fill_cylinder_deactivation(CS_SP)
+    cyl = CS_SP.zoompilot.cylinderDeactivation
+    assert cyl.state == 'normal'
+    assert cyl.entryProgress == 0.0
+
+  def test_mazda_fields_publish_through(self):
+    ext = _card_ext(SimpleNamespace(cyl_state='entry', cyl_entry_progress=3 / 7))
+    CS_SP = _car_state_sp()
+    ext.fill_cylinder_deactivation(CS_SP)
+    cyl = CS_SP.zoompilot.cylinderDeactivation
+    assert cyl.state == 'entry'
+    assert abs(cyl.entryProgress - 3 / 7) < 1e-6

--- a/openpilot/sunnypilot/sunnylink/settings_ui.json
+++ b/openpilot/sunnypilot/sunnylink/settings_ui.json
@@ -1588,6 +1588,19 @@
                   "equals": true
                 }
               ]
+            },
+            {
+              "key": "CylinderDeactivationUI",
+              "widget": "toggle",
+              "title": "Cylinder Status Ring",
+              "description": "Ring around the driver-monitoring icon showing cylinder deactivation and engine braking status, on engines that report the cylinder mode on the bus.",
+              "visibility": [
+                {
+                  "type": "capability",
+                  "field": "brand",
+                  "equals": "mazda"
+                }
+              ]
             }
           ]
         },

--- a/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/visuals.yaml
+++ b/openpilot/sunnypilot/sunnylink/settings_ui_src/pages/visuals.yaml
@@ -66,6 +66,15 @@ sections:
     - $ref: '#/macros/hide_on_mici'
     enablement:
     - $ref: '#/macros/longitudinal'
+  - key: CylinderDeactivationUI
+    widget: toggle
+    title: Cylinder Status Ring
+    description: Ring around the driver-monitoring icon showing cylinder deactivation and engine braking status, on
+      engines that report the cylinder mode on the bus.
+    visibility:
+    - type: capability
+      field: brand
+      equals: mazda
 - id: developer_ui
   title: Developer UI Info
   description: Speedometer and debug display options


### PR DESCRIPTION
## Why
Display cylinder deactivation and engine braking state in the onroad UI.

## What
Opt-in toggle (default off, Mazda-only): Settings → Visuals → "Cylinder Status Ring". When enabled, a ring gauge wraps the driver-monitoring circle on tici and the steering-wheel icon on mici. It shows the current engine state: ramping into cylinder deactivation, latched at 2 of 4 cylinders, or fuel cut. The state rides a new `CarStateZP.cylinderDeactivation` field published by `card_ext`.

## Dependency
Depends on zoompilot/opendbc#12

## Validation
- device (tizi): exercised on the road during development — the gauge renders and tracks ramp, latch and fuel cut.

## Known limitation
- decode validated on one CX-5 2022 2.5L; other Mazda engines unverified (same caveat as the opendbc PR).
- mici harness-verified; not yet checked on a mici device.

## AI Usage
Disclaimer: GLM-5.3-Flash by Z.ai was used to help develop, debug, and document this submission. All changes were reviewed and validated by a human.